### PR TITLE
Switch to full runtime + minor improvments

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -22,12 +22,14 @@ const K: u32[] = [
 // state stored in H0-H7
 var H0: u32, H1: u32, H2: u32, H3: u32, H4: u32, H5: u32, H6: u32, H7: u32;
 
+// prealloc buffers
 var temp  = new ArrayBuffer(256); // temporary state
 var buffer = new ArrayBuffer(128); // buffer for data to hash
+var out = new ArrayBuffer(digestLength); // buffer for output
+
 var bufferLength = 0; // number of bytes in buffer
 var bytesHashed = 0; // number of total bytes hashed
 var finished = false;
-var out = new ArrayBuffer(digestLength);
 
 @inline
 function load32(ptr: usize, offset: usize): u32 {

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -1,7 +1,7 @@
 
 //https://github.com/dchest/fast-sha256-js/blob/master/src/sha256.ts
 export const UINT8ARRAY_ID = idof<Uint8Array>();
-const digestLength = 32;
+const DIGEST_LENGTH = 32;
 
 const K: u32[] = [
   0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b,
@@ -23,9 +23,9 @@ const K: u32[] = [
 var H0: u32, H1: u32, H2: u32, H3: u32, H4: u32, H5: u32, H6: u32, H7: u32;
 
 // prealloc buffers
-var temp  = new ArrayBuffer(256); // temporary state
 var buffer = new ArrayBuffer(128); // buffer for data to hash
-var out = new ArrayBuffer(digestLength); // buffer for output
+var temp   = new ArrayBuffer(256); // temporary state
+var out    = new ArrayBuffer(DIGEST_LENGTH); // buffer for output
 
 var bufferLength = 0; // number of bytes in buffer
 var bytesHashed = 0; // number of total bytes hashed
@@ -137,6 +137,7 @@ function reset(): void {
 export function clean(): void {
   memory.fill(changetype<usize>(buffer), 0, buffer.byteLength);
   memory.fill(changetype<usize>(temp),   0, temp.byteLength);
+  memory.fill(changetype<usize>(out),    0, out.byteLength);
   reset();
 }
 
@@ -145,11 +146,9 @@ export function update(data: Uint8Array, dataLength: i32): void {
     throw new Error("SHA256: can't update because hash was finished.");
   }
 
-  let dataBuffer = data.buffer;
   let dataPtr = data.dataStart;
   let tempPtr = changetype<usize>(temp);
   let bufferPtr = changetype<usize>(buffer);
-  let dataBufferPtr = changetype<usize>(dataBuffer);
   let dataPos = 0;
   bytesHashed += dataLength;
   if (bufferLength > 0) {
@@ -163,7 +162,7 @@ export function update(data: Uint8Array, dataLength: i32): void {
     }
   }
   if (dataLength >= 64) {
-    dataPos = hashBlocks(tempPtr, dataBufferPtr, dataPos, dataLength);
+    dataPos = hashBlocks(tempPtr, dataPtr, dataPos, dataLength);
     dataLength &= 63;
   }
   memory.copy(bufferPtr, dataPtr + dataPos, dataLength);
@@ -210,7 +209,7 @@ export function hashMe(data: Uint8Array): Uint8Array {
   update(data, data.length);
   finish(out);
 
-  let ret = new Uint8Array(digestLength);
-  memory.copy(ret.dataStart, changetype<usize>(out), digestLength);
+  let ret = new Uint8Array(DIGEST_LENGTH);
+  memory.copy(ret.dataStart, changetype<usize>(out), DIGEST_LENGTH);
   return ret;
 }

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -178,12 +178,13 @@ export function finish(out: ArrayBuffer): void {
     let bufferPtr = changetype<usize>(buffer);
 
     store8(bufferPtr, left, 0x80);
-    for (let i = left + 1, len = padLength - 8; i < len; i++) {
-      store8(bufferPtr, i, 0);
-    }
+    // for (let i = left + 1, len = padLength - 8; i < len; i++) {
+    //   store8(bufferPtr, i, 0);
+    // }
+    memory.fill(bufferPtr + left + 1, 0, padLength - left - 9);
 
-    store32(bufferPtr, (padLength - 8) >> alignof<u32>(), bswap(bitLenHi));
-    store32(bufferPtr, (padLength - 4) >> alignof<u32>(), bswap(bitLenLo));
+    store<u32>(bufferPtr + padLength - 8, bswap(bitLenHi));
+    store<u32>(bufferPtr + padLength - 4, bswap(bitLenLo));
 
     hashBlocks(temp, buffer, 0, padLength);
     finished = true;

--- a/build/optimized.wat
+++ b/build/optimized.wat
@@ -36,10 +36,10 @@
  (global $assembly/index/H7 (mut i32) (i32.const 0))
  (global $assembly/index/temp (mut i32) (i32.const 0))
  (global $assembly/index/buffer (mut i32) (i32.const 0))
+ (global $assembly/index/out (mut i32) (i32.const 0))
  (global $assembly/index/bufferLength (mut i32) (i32.const 0))
  (global $assembly/index/bytesHashed (mut i32) (i32.const 0))
  (global $assembly/index/finished (mut i32) (i32.const 0))
- (global $assembly/index/out (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 784))
  (export "memory" (memory $0))
  (export "__alloc" (func $~lib/rt/tlsf/__alloc))
@@ -2914,7 +2914,7 @@
    call $~lib/rt/pure/__release
    i32.const 632
    i32.const 744
-   i32.const 143
+   i32.const 145
    i32.const 4
    call $~lib/builtins/abort
    unreachable

--- a/build/optimized.wat
+++ b/build/optimized.wat
@@ -3080,7 +3080,6 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (local $6 i32)
   local.get $0
   i32.const 828
   i32.gt_u
@@ -3099,62 +3098,40 @@
   i32.eqz
   if
    global.get $assembly/index/bytesHashed
-   local.tee $2
+   local.tee $1
    i32.const 536870912
    i32.div_s
    local.set $4
-   local.get $2
-   i32.const 3
-   i32.shl
-   local.set $5
-   global.get $assembly/index/buffer
-   local.tee $3
    global.get $assembly/index/bufferLength
-   local.tee $1
+   local.tee $3
+   global.get $assembly/index/buffer
+   local.tee $5
    i32.add
+   local.tee $2
    i32.const 128
    i32.store8
-   local.get $1
+   local.get $2
    i32.const 1
    i32.add
-   local.set $1
    i32.const 64
-   local.get $2
+   local.get $1
    i32.const 63
    i32.and
    i32.const 56
    i32.ge_s
    i32.shl
    local.tee $2
-   i32.const 8
-   i32.sub
-   local.set $6
-   loop $loop|0
-    local.get $1
-    local.get $6
-    i32.lt_s
-    if
-     local.get $1
-     local.get $3
-     i32.add
-     i32.const 0
-     i32.store8
-     local.get $1
-     i32.const 1
-     i32.add
-     local.set $1
-     br $loop|0
-    end
-   end
-   local.get $2
-   i32.const 8
-   i32.sub
-   i32.const 2
-   i32.shr_s
-   i32.const 2
-   i32.shl
    local.get $3
+   i32.sub
+   i32.const 9
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $2
+   local.get $5
    i32.add
+   local.tee $3
+   i32.const 8
+   i32.sub
    local.get $4
    i32.const -16711936
    i32.and
@@ -3167,21 +3144,18 @@
    i32.rotr
    i32.or
    i32.store
-   local.get $2
+   local.get $3
    i32.const 4
    i32.sub
-   i32.const 2
-   i32.shr_s
-   i32.const 2
+   local.get $1
+   i32.const 3
    i32.shl
-   local.get $3
-   i32.add
-   local.get $5
+   local.tee $1
    i32.const -16711936
    i32.and
    i32.const 8
    i32.rotl
-   local.get $5
+   local.get $1
    i32.const 16711935
    i32.and
    i32.const 8

--- a/build/optimized.wat
+++ b/build/optimized.wat
@@ -2582,109 +2582,79 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
-  local.get $0
-  i32.const 828
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   local.tee $6
-   local.get $6
-   i32.load offset=4
-   i32.const 1
-   i32.add
-   i32.store offset=4
-  end
-  local.get $1
-  i32.const 828
-  i32.gt_u
-  if
-   local.get $1
-   i32.const 16
-   i32.sub
-   local.tee $6
-   local.get $6
-   i32.load offset=4
-   i32.const 1
-   i32.add
-   i32.store offset=4
-  end
   i32.const 500
   i32.load
-  local.set $15
-  local.get $1
-  local.set $11
-  local.get $0
-  local.set $7
+  local.set $14
   loop $continue|0
    local.get $3
    i32.const 64
-   i32.ge_u
+   i32.lt_u
+   i32.eqz
    if
     global.get $assembly/index/H0
-    local.set $8
-    global.get $assembly/index/H1
-    local.set $12
-    global.get $assembly/index/H2
     local.set $6
-    global.get $assembly/index/H3
-    local.set $13
-    global.get $assembly/index/H4
+    global.get $assembly/index/H1
+    local.set $8
+    global.get $assembly/index/H2
     local.set $9
+    global.get $assembly/index/H3
+    local.set $12
+    global.get $assembly/index/H4
+    local.set $7
     global.get $assembly/index/H5
-    local.set $1
+    local.set $10
     global.get $assembly/index/H6
-    local.set $0
+    local.set $11
     global.get $assembly/index/H7
-    local.set $14
+    local.set $13
     i32.const 0
     local.set $4
     loop $loop|1
-     local.get $4
-     i32.const 16
-     i32.lt_u
-     if
+     block $break|1
+      local.get $4
+      i32.const 16
+      i32.ge_u
+      br_if $break|1
       local.get $4
       i32.const 2
       i32.shl
-      local.tee $5
+      local.get $0
+      i32.add
+      local.get $4
+      i32.const 2
+      i32.shl
       local.get $2
       i32.add
-      local.set $10
-      local.get $5
-      local.get $7
-      i32.add
-      local.get $10
-      i32.const 3
-      i32.add
-      local.get $11
-      i32.add
-      i32.load8_u
-      local.get $10
-      local.get $11
+      local.tee $5
+      local.get $1
       i32.add
       i32.load8_u
       i32.const 24
       i32.shl
-      local.get $10
+      local.get $5
       i32.const 1
       i32.add
-      local.get $11
+      local.get $1
       i32.add
       i32.load8_u
       i32.const 16
       i32.shl
       i32.or
-      local.get $10
+      local.get $5
       i32.const 2
       i32.add
-      local.get $11
+      local.get $1
       i32.add
       i32.load8_u
       i32.const 8
       i32.shl
       i32.or
+      local.get $5
+      i32.const 3
+      i32.add
+      local.get $1
+      i32.add
+      i32.load8_u
       i32.or
       i32.store
       local.get $4
@@ -2697,21 +2667,22 @@
     i32.const 16
     local.set $4
     loop $loop|2
-     local.get $4
-     i32.const 64
-     i32.lt_u
-     if
+     block $break|2
+      local.get $4
+      i32.const 64
+      i32.ge_u
+      br_if $break|2
       local.get $4
       i32.const 2
       i32.shl
-      local.get $7
+      local.get $0
       i32.add
       local.get $4
       i32.const 16
       i32.sub
       i32.const 2
       i32.shl
-      local.get $7
+      local.get $0
       i32.add
       i32.load
       local.get $4
@@ -2719,7 +2690,7 @@
       i32.sub
       i32.const 2
       i32.shl
-      local.get $7
+      local.get $0
       i32.add
       i32.load
       local.tee $5
@@ -2738,7 +2709,7 @@
       i32.sub
       i32.const 2
       i32.shl
-      local.get $7
+      local.get $0
       i32.add
       i32.load
       local.get $4
@@ -2746,7 +2717,7 @@
       i32.sub
       i32.const 2
       i32.shl
-      local.get $7
+      local.get $0
       i32.add
       i32.load
       local.tee $5
@@ -2774,89 +2745,93 @@
     i32.const 0
     local.set $4
     loop $loop|3
-     local.get $4
-     i32.const 64
-     i32.lt_u
-     if
+     block $break|3
+      local.get $4
+      i32.const 64
+      i32.ge_u
+      br_if $break|3
       local.get $4
       i32.const 2
       i32.shl
-      local.tee $5
+      local.get $0
+      i32.add
+      i32.load
+      local.get $4
+      i32.const 2
+      i32.shl
+      local.get $14
+      i32.add
+      i32.load
       local.get $7
-      i32.add
-      i32.load
-      local.get $5
-      local.get $15
-      i32.add
-      i32.load
-      local.get $9
       i32.const 6
       i32.rotr
-      local.get $9
+      local.get $7
       i32.const 11
       i32.rotr
       i32.xor
-      local.get $9
+      local.get $7
       i32.const 25
       i32.rotr
       i32.xor
-      local.get $1
-      local.get $9
+      local.get $7
+      local.get $10
       i32.and
-      local.get $9
+      local.get $7
       i32.const -1
       i32.xor
-      local.get $0
+      local.get $11
       i32.and
       i32.xor
       i32.add
-      local.get $14
+      local.get $13
       i32.add
       i32.add
       i32.add
-      local.set $10
-      local.get $8
+      local.set $5
+      local.get $6
       i32.const 2
       i32.rotr
-      local.get $8
+      local.get $6
       i32.const 13
       i32.rotr
       i32.xor
-      local.get $8
+      local.get $6
       i32.const 22
       i32.rotr
       i32.xor
-      local.get $6
-      local.get $12
-      i32.and
       local.get $8
-      local.get $12
-      i32.and
-      local.get $6
-      local.get $8
-      i32.and
-      i32.xor
-      i32.xor
-      i32.add
-      local.get $0
-      local.set $14
-      local.get $1
-      local.set $0
       local.get $9
-      local.set $1
-      local.get $10
-      local.get $13
+      i32.and
+      local.get $6
+      local.get $8
+      i32.and
+      local.get $6
+      local.get $9
+      i32.and
+      i32.xor
+      i32.xor
       i32.add
+      local.set $15
+      local.get $11
+      local.set $13
+      local.get $10
+      local.set $11
+      local.get $7
+      local.set $10
+      local.get $5
+      local.get $12
+      i32.add
+      local.set $7
+      local.get $9
+      local.set $12
+      local.get $8
       local.set $9
       local.get $6
-      local.set $13
-      local.get $12
-      local.set $6
-      local.get $8
-      local.set $12
-      local.get $10
-      i32.add
       local.set $8
+      local.get $5
+      local.get $15
+      i32.add
+      local.set $6
       local.get $4
       i32.const 1
       i32.add
@@ -2865,35 +2840,35 @@
      end
     end
     global.get $assembly/index/H0
-    local.get $8
+    local.get $6
     i32.add
     global.set $assembly/index/H0
     global.get $assembly/index/H1
-    local.get $12
+    local.get $8
     i32.add
     global.set $assembly/index/H1
     global.get $assembly/index/H2
-    local.get $6
+    local.get $9
     i32.add
     global.set $assembly/index/H2
     global.get $assembly/index/H3
-    local.get $13
+    local.get $12
     i32.add
     global.set $assembly/index/H3
     global.get $assembly/index/H4
-    local.get $9
+    local.get $7
     i32.add
     global.set $assembly/index/H4
     global.get $assembly/index/H5
-    local.get $1
+    local.get $10
     i32.add
     global.set $assembly/index/H5
     global.get $assembly/index/H6
-    local.get $0
+    local.get $11
     i32.add
     global.set $assembly/index/H6
     global.get $assembly/index/H7
-    local.get $14
+    local.get $13
     i32.add
     global.set $assembly/index/H7
     local.get $2
@@ -2907,10 +2882,6 @@
     br $continue|0
    end
   end
-  local.get $7
-  call $~lib/rt/pure/__release
-  local.get $11
-  call $~lib/rt/pure/__release
   local.get $2
  )
  (func $assembly/index/update (; 30 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
@@ -2921,12 +2892,13 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
-  local.tee $2
+  local.tee $3
   i32.const 828
   i32.gt_u
   if
-   local.get $2
+   local.get $3
    i32.const 16
    i32.sub
    local.tee $0
@@ -2938,32 +2910,17 @@
   end
   global.get $assembly/index/finished
   if
-   local.get $2
+   local.get $3
    call $~lib/rt/pure/__release
    i32.const 632
    i32.const 744
-   i32.const 145
+   i32.const 143
    i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $2
+  local.get $3
   i32.load
-  local.tee $5
-  i32.const 828
-  i32.gt_u
-  if
-   local.get $5
-   i32.const 16
-   i32.sub
-   local.tee $0
-   local.get $0
-   i32.load offset=4
-   i32.const 1
-   i32.add
-   i32.store offset=4
-  end
-  local.get $5
   local.tee $0
   i32.const 828
   i32.gt_u
@@ -2971,20 +2928,37 @@
    local.get $0
    i32.const 16
    i32.sub
-   local.tee $3
-   local.get $3
+   local.tee $2
+   local.get $2
    i32.load offset=4
    i32.const 1
    i32.add
    i32.store offset=4
   end
   local.get $0
-  local.set $3
+  local.tee $2
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $2
+   i32.const 16
+   i32.sub
+   local.tee $4
+   local.get $4
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
   local.get $2
+  local.set $4
+  local.get $3
   i32.load offset=4
-  local.set $6
-  global.get $assembly/index/buffer
   local.set $7
+  global.get $assembly/index/temp
+  local.set $8
+  global.get $assembly/index/buffer
+  local.set $6
   global.get $assembly/index/bytesHashed
   local.get $1
   i32.add
@@ -3004,20 +2978,20 @@
     select
     if
      global.get $assembly/index/bufferLength
-     local.tee $8
+     local.tee $9
      i32.const 1
      i32.add
      global.set $assembly/index/bufferLength
-     local.get $4
-     local.tee $0
+     local.get $5
+     local.tee $2
      i32.const 1
      i32.add
-     local.set $4
-     local.get $7
-     local.get $8
-     i32.add
-     local.get $0
+     local.set $5
      local.get $6
+     local.get $9
+     i32.add
+     local.get $2
+     local.get $7
      i32.add
      i32.load8_u
      i32.store8
@@ -3032,8 +3006,8 @@
    i32.const 64
    i32.eq
    if
-    global.get $assembly/index/temp
-    global.get $assembly/index/buffer
+    local.get $8
+    local.get $6
     i32.const 0
     i32.const 64
     call $assembly/index/hashBlocks
@@ -3046,20 +3020,20 @@
   i32.const 64
   i32.ge_s
   if
-   global.get $assembly/index/temp
-   local.get $3
+   local.get $8
    local.get $4
+   local.get $5
    local.get $1
    call $assembly/index/hashBlocks
-   local.set $4
+   local.set $5
    local.get $1
    i32.const 63
    i32.and
    local.set $1
   end
-  local.get $7
-  local.get $4
   local.get $6
+  local.get $5
+  local.get $7
   i32.add
   local.get $1
   call $~lib/memory/memory.copy
@@ -3067,11 +3041,11 @@
   local.get $1
   i32.add
   global.set $assembly/index/bufferLength
-  local.get $5
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $4
   call $~lib/rt/pure/__release
   local.get $3
-  call $~lib/rt/pure/__release
-  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $assembly/index/finish (; 31 ;) (type $FUNCSIG$vi) (param $0 i32)
@@ -3080,6 +3054,7 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
   local.get $0
   i32.const 828
   i32.gt_u
@@ -3102,10 +3077,11 @@
    i32.const 536870912
    i32.div_s
    local.set $4
-   global.get $assembly/index/bufferLength
-   local.tee $3
+   global.get $assembly/index/temp
    global.get $assembly/index/buffer
    local.tee $5
+   global.get $assembly/index/bufferLength
+   local.tee $3
    i32.add
    local.tee $2
    i32.const 128
@@ -3162,8 +3138,7 @@
    i32.rotr
    i32.or
    i32.store
-   global.get $assembly/index/temp
-   global.get $assembly/index/buffer
+   local.get $5
    i32.const 0
    local.get $2
    call $assembly/index/hashBlocks

--- a/build/optimized.wat
+++ b/build/optimized.wat
@@ -1,24 +1,30 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
- (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
  (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
  (type $FUNCSIG$viii (func (param i32 i32 i32)))
- (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
- (data (i32.const 9) "\01\00\00\01")
- (data (i32.const 21) "\01\00\00\98/\8aB\91D7q\cf\fb\c0\b5\a5\db\b5\e9[\c2V9\f1\11\f1Y\a4\82?\92\d5^\1c\ab\98\aa\07\d8\01[\83\12\be\851$\c3}\0cUt]\ber\fe\b1\de\80\a7\06\dc\9bt\f1\9b\c1\c1i\9b\e4\86G\be\ef\c6\9d\c1\0f\cc\a1\0c$o,\e9-\aa\84tJ\dc\a9\b0\\\da\88\f9vRQ>\98m\c61\a8\c8\'\03\b0\c7\7fY\bf\f3\0b\e0\c6G\91\a7\d5Qc\ca\06g))\14\85\n\b7\'8!\1b.\fcm,M\13\0d8STs\ne\bb\njv.\c9\c2\81\85,r\92\a1\e8\bf\a2Kf\1a\a8p\8bK\c2\a3Ql\c7\19\e8\92\d1$\06\99\d6\855\0e\f4p\a0j\10\16\c1\a4\19\08l7\1eLwH\'\b5\bc\b04\b3\0c\1c9J\aa\d8NO\ca\9c[\f3o.h\ee\82\8ftoc\a5x\14x\c8\84\08\02\c7\8c\fa\ff\be\90\eblP\a4\f7\a3\f9\be\f2xq\c6")
- (data (i32.const 280) "\10\00\00\00\01\00\00\00\04\00\00\00\10\00\00\00\18\00\00\00\18\00\00\00\00\01\00\00@")
- (data (i32.const 312) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
- (data (i32.const 360) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
- (data (i32.const 416) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00S\00H\00A\002\005\006\00:\00 \00c\00a\00n\00\'\00t\00 \00u\00p\00d\00a\00t\00e\00 \00b\00e\00c\00a\00u\00s\00e\00 \00h\00a\00s\00h\00 \00w\00a\00s\00 \00f\00i\00n\00i\00s\00h\00e\00d\00.")
- (data (i32.const 528) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00a\00s\00s\00e\00m\00b\00l\00y\00/\00i\00n\00d\00e\00x\00.\00t\00s")
- (data (i32.const 584) "\05\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\001\00\00\00\02\00\00\00\93\00\00\00\02")
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
- (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (data (i32.const 8) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
+ (data (i32.const 64) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data (i32.const 112) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
+ (data (i32.const 168) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
+ (data (i32.const 209) "\01\00\00\01")
+ (data (i32.const 221) "\01\00\00\98/\8aB\91D7q\cf\fb\c0\b5\a5\db\b5\e9[\c2V9\f1\11\f1Y\a4\82?\92\d5^\1c\ab\98\aa\07\d8\01[\83\12\be\851$\c3}\0cUt]\ber\fe\b1\de\80\a7\06\dc\9bt\f1\9b\c1\c1i\9b\e4\86G\be\ef\c6\9d\c1\0f\cc\a1\0c$o,\e9-\aa\84tJ\dc\a9\b0\\\da\88\f9vRQ>\98m\c61\a8\c8\'\03\b0\c7\7fY\bf\f3\0b\e0\c6G\91\a7\d5Qc\ca\06g))\14\85\n\b7\'8!\1b.\fcm,M\13\0d8STs\ne\bb\njv.\c9\c2\81\85,r\92\a1\e8\bf\a2Kf\1a\a8p\8bK\c2\a3Ql\c7\19\e8\92\d1$\06\99\d6\855\0e\f4p\a0j\10\16\c1\a4\19\08l7\1eLwH\'\b5\bc\b04\b3\0c\1c9J\aa\d8NO\ca\9c[\f3o.h\ee\82\8ftoc\a5x\14x\c8\84\08\02\c7\8c\fa\ff\be\90\eblP\a4\f7\a3\f9\be\f2xq\c6")
+ (data (i32.const 480) "\10\00\00\00\01\00\00\00\04\00\00\00\10\00\00\00\e0\00\00\00\e0\00\00\00\00\01\00\00@")
+ (data (i32.const 512) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data (i32.const 560) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s")
+ (data (i32.const 616) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00S\00H\00A\002\005\006\00:\00 \00c\00a\00n\00\'\00t\00 \00u\00p\00d\00a\00t\00e\00 \00b\00e\00c\00a\00u\00s\00e\00 \00h\00a\00s\00h\00 \00w\00a\00s\00 \00f\00i\00n\00i\00s\00h\00e\00d\00.")
+ (data (i32.const 728) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00a\00s\00s\00e\00m\00b\00l\00y\00/\00i\00n\00d\00e\00x\00.\00t\00s")
+ (data (i32.const 784) "\05\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\001\00\00\00\02\00\00\00\93\00\00\00\02")
+ (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/rt/pure/CUR (mut i32) (i32.const 0))
+ (global $~lib/rt/pure/END (mut i32) (i32.const 0))
+ (global $~lib/rt/pure/ROOTS (mut i32) (i32.const 0))
  (global $assembly/index/UINT8ARRAY_ID i32 (i32.const 3))
  (global $assembly/index/H0 (mut i32) (i32.const 0))
  (global $assembly/index/H1 (mut i32) (i32.const 0))
@@ -34,12 +40,12 @@
  (global $assembly/index/bytesHashed (mut i32) (i32.const 0))
  (global $assembly/index/finished (mut i32) (i32.const 0))
  (global $assembly/index/out (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 584))
+ (global $~lib/rt/__rtti_base i32 (i32.const 784))
  (export "memory" (memory $0))
- (export "__alloc" (func $~lib/rt/stub/__alloc))
- (export "__retain" (func $~lib/rt/stub/__retain))
- (export "__release" (func $~lib/rt/stub/__release))
- (export "__collect" (func $~lib/rt/stub/__collect))
+ (export "__alloc" (func $~lib/rt/tlsf/__alloc))
+ (export "__retain" (func $~lib/rt/pure/__retain))
+ (export "__release" (func $~lib/rt/pure/__release))
+ (export "__collect" (func $~lib/rt/pure/__collect))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (export "UINT8ARRAY_ID" (global $assembly/index/UINT8ARRAY_ID))
  (export "clean" (func $assembly/index/clean))
@@ -47,677 +53,821 @@
  (export "finish" (func $assembly/index/finish))
  (export "hashMe" (func $assembly/index/hashMe))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/removeBlock (; 1 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  local.get $0
-  i32.const 1073741808
-  i32.gt_u
-  if
-   unreachable
-  end
-  global.get $~lib/rt/stub/offset
-  i32.const 16
-  i32.add
-  local.tee $3
-  local.get $0
-  i32.const 1
-  local.get $0
-  i32.const 1
-  i32.gt_u
-  select
-  i32.add
-  i32.const 15
-  i32.add
-  i32.const -16
+  local.get $1
+  i32.load
+  i32.const -4
   i32.and
   local.tee $2
-  memory.size
-  local.tee $4
-  i32.const 16
-  i32.shl
-  i32.gt_u
-  if
-   local.get $4
+  i32.const 256
+  i32.lt_u
+  if (result i32)
    local.get $2
-   local.get $3
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const -65536
-   i32.and
-   i32.const 16
+   i32.const 4
    i32.shr_u
-   local.tee $5
-   local.get $4
-   local.get $5
-   i32.gt_s
-   select
-   memory.grow
+   local.set $4
    i32.const 0
-   i32.lt_s
-   if
-    local.get $5
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
+  else   
+   local.get $2
+   i32.const 31
+   local.get $2
+   i32.clz
+   i32.sub
+   local.tee $3
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $4
+   local.get $3
+   i32.const 7
+   i32.sub
   end
-  local.get $2
-  global.set $~lib/rt/stub/offset
-  local.get $3
-  i32.const 16
-  i32.sub
-  local.tee $2
+  local.set $3
   local.get $1
-  i32.store offset=8
-  local.get $2
-  local.get $0
-  i32.store offset=12
-  local.get $3
- )
- (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
- )
- (func $~lib/rt/stub/__release (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
-  nop
- )
- (func $~lib/rt/stub/__collect (; 4 ;) (type $FUNCSIG$v)
-  nop
- )
- (func $~lib/memory/memory.fill (; 5 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
-  (local $2 i32)
-  block $~lib/util/memory/memset|inlined.0
-   local.get $1
-   i32.eqz
-   br_if $~lib/util/memory/memset|inlined.0
-   local.get $0
-   i32.const 0
-   i32.store8
-   local.get $0
-   local.get $1
-   i32.add
-   i32.const 1
-   i32.sub
-   i32.const 0
-   i32.store8
-   local.get $1
-   i32.const 2
-   i32.le_u
-   br_if $~lib/util/memory/memset|inlined.0
-   local.get $0
-   i32.const 1
-   i32.add
-   i32.const 0
-   i32.store8
-   local.get $0
-   i32.const 2
-   i32.add
-   i32.const 0
-   i32.store8
-   local.get $0
-   local.get $1
-   i32.add
-   local.tee $2
-   i32.const 2
-   i32.sub
-   i32.const 0
-   i32.store8
-   local.get $2
-   i32.const 3
-   i32.sub
-   i32.const 0
-   i32.store8
-   local.get $1
-   i32.const 6
-   i32.le_u
-   br_if $~lib/util/memory/memset|inlined.0
-   local.get $0
-   i32.const 3
-   i32.add
-   i32.const 0
-   i32.store8
-   local.get $0
-   local.get $1
-   i32.add
-   i32.const 4
-   i32.sub
-   i32.const 0
-   i32.store8
-   local.get $1
-   i32.const 8
-   i32.le_u
-   br_if $~lib/util/memory/memset|inlined.0
-   local.get $1
-   i32.const 0
-   local.get $0
-   i32.sub
-   i32.const 3
-   i32.and
-   local.tee $1
-   i32.sub
-   local.get $0
-   local.get $1
-   i32.add
-   local.tee $0
-   i32.const 0
-   i32.store
-   i32.const -4
-   i32.and
-   local.tee $1
-   local.get $0
-   i32.add
-   i32.const 4
-   i32.sub
-   i32.const 0
-   i32.store
-   local.get $1
-   i32.const 8
-   i32.le_u
-   br_if $~lib/util/memory/memset|inlined.0
-   local.get $0
-   i32.const 4
-   i32.add
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.const 8
-   i32.add
-   i32.const 0
-   i32.store
-   local.get $0
-   local.get $1
-   i32.add
-   local.tee $2
-   i32.const 12
-   i32.sub
-   i32.const 0
-   i32.store
-   local.get $2
-   i32.const 8
-   i32.sub
-   i32.const 0
-   i32.store
-   local.get $1
-   i32.const 24
-   i32.le_u
-   br_if $~lib/util/memory/memset|inlined.0
-   local.get $0
-   i32.const 12
-   i32.add
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.const 16
-   i32.add
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.const 20
-   i32.add
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.const 24
-   i32.add
-   i32.const 0
-   i32.store
-   local.get $0
-   local.get $1
-   i32.add
-   local.tee $2
-   i32.const 28
-   i32.sub
-   i32.const 0
-   i32.store
-   local.get $2
-   i32.const 24
-   i32.sub
-   i32.const 0
-   i32.store
-   local.get $2
-   i32.const 20
-   i32.sub
-   i32.const 0
-   i32.store
-   local.get $2
-   i32.const 16
-   i32.sub
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.const 4
-   i32.and
-   i32.const 24
-   i32.add
-   local.tee $2
-   local.get $0
-   i32.add
-   local.set $0
-   local.get $1
-   local.get $2
-   i32.sub
-   local.set $1
-   loop $continue|0
-    local.get $1
-    i32.const 32
-    i32.ge_u
-    if
-     local.get $0
-     i64.const 0
-     i64.store
-     local.get $0
-     i32.const 8
-     i32.add
-     i64.const 0
-     i64.store
-     local.get $0
-     i32.const 16
-     i32.add
-     i64.const 0
-     i64.store
-     local.get $0
-     i32.const 24
-     i32.add
-     i64.const 0
-     i64.store
-     local.get $1
-     i32.const 32
-     i32.sub
-     local.set $1
-     local.get $0
-     i32.const 32
-     i32.add
-     local.set $0
-     br $continue|0
-    end
-   end
-  end
- )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 6 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  (local $1 i32)
-  local.get $0
-  i32.const 1073741808
-  i32.gt_u
+  i32.load offset=20
+  local.set $2
+  local.get $1
+  i32.load offset=16
+  local.tee $5
   if
-   i32.const 328
-   i32.const 376
-   i32.const 57
-   i32.const 42
-   call $~lib/builtins/abort
-   unreachable
+   local.get $5
+   local.get $2
+   i32.store offset=20
   end
+  local.get $2
+  if
+   local.get $2
+   local.get $5
+   i32.store offset=16
+  end
+  local.get $3
+  i32.const 4
+  i32.shl
+  local.get $4
+  i32.add
+  i32.const 2
+  i32.shl
   local.get $0
-  i32.const 0
-  call $~lib/rt/stub/__alloc
-  local.tee $1
-  local.get $0
-  call $~lib/memory/memory.fill
+  i32.add
+  i32.load offset=96
   local.get $1
+  i32.eq
+  if
+   local.get $3
+   i32.const 4
+   i32.shl
+   local.get $4
+   i32.add
+   i32.const 2
+   i32.shl
+   local.get $0
+   i32.add
+   local.get $2
+   i32.store offset=96
+   local.get $2
+   i32.eqz
+   if
+    local.get $3
+    i32.const 2
+    i32.shl
+    local.get $0
+    i32.add
+    local.get $3
+    i32.const 2
+    i32.shl
+    local.get $0
+    i32.add
+    i32.load offset=4
+    i32.const 1
+    local.get $4
+    i32.shl
+    i32.const -1
+    i32.xor
+    i32.and
+    local.tee $1
+    i32.store offset=4
+    local.get $1
+    i32.eqz
+    if
+     local.get $0
+     local.get $0
+     i32.load
+     i32.const 1
+     local.get $3
+     i32.shl
+     i32.const -1
+     i32.xor
+     i32.and
+     i32.store
+    end
+   end
+  end
  )
- (func $assembly/index/reset (; 7 ;) (type $FUNCSIG$v)
-  i32.const 1779033703
-  global.set $assembly/index/H0
-  i32.const -1150833019
-  global.set $assembly/index/H1
-  i32.const 1013904242
-  global.set $assembly/index/H2
-  i32.const -1521486534
-  global.set $assembly/index/H3
-  i32.const 1359893119
-  global.set $assembly/index/H4
-  i32.const -1694144372
-  global.set $assembly/index/H5
-  i32.const 528734635
-  global.set $assembly/index/H6
-  i32.const 1541459225
-  global.set $assembly/index/H7
-  i32.const 0
-  global.set $assembly/index/bufferLength
-  i32.const 0
-  global.set $assembly/index/bytesHashed
-  i32.const 0
-  global.set $assembly/index/finished
- )
- (func $assembly/index/clean (; 8 ;) (type $FUNCSIG$v)
-  (local $0 i32)
-  (local $1 i32)
-  global.get $assembly/index/buffer
-  local.tee $0
-  i32.const 16
-  i32.sub
-  i32.load offset=12
-  local.set $1
-  local.get $0
-  local.get $1
-  call $~lib/memory/memory.fill
-  global.get $assembly/index/temp
-  local.tee $0
-  i32.const 16
-  i32.sub
-  i32.load offset=12
-  local.set $1
-  local.get $0
-  local.get $1
-  call $~lib/memory/memory.fill
-  call $assembly/index/reset
- )
- (func $assembly/index/hashBlocks (; 9 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/tlsf/insertBlock (; 2 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
-  (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  i32.const 296
+  local.get $1
   i32.load
-  local.set $15
-  loop $continue|0
+  local.set $3
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $1
+  i32.load
+  i32.const -4
+  i32.and
+  i32.add
+  local.tee $4
+  i32.load
+  local.tee $5
+  i32.const 1
+  i32.and
+  if
    local.get $3
-   i32.const 64
-   i32.ge_u
+   i32.const -4
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $2
+   i32.const 1073741808
+   i32.lt_u
    if
-    global.get $assembly/index/H0
-    local.set $6
-    global.get $assembly/index/H1
-    local.set $8
-    global.get $assembly/index/H2
-    local.set $9
-    global.get $assembly/index/H3
-    local.set $12
-    global.get $assembly/index/H4
-    local.set $7
-    global.get $assembly/index/H5
-    local.set $10
-    global.get $assembly/index/H6
-    local.set $11
-    global.get $assembly/index/H7
-    local.set $13
+    local.get $0
+    local.get $4
+    call $~lib/rt/tlsf/removeBlock
+    local.get $1
+    local.get $3
+    i32.const 3
+    i32.and
+    local.get $2
+    i32.or
+    local.tee $3
+    i32.store
+    local.get $1
+    i32.const 16
+    i32.add
+    local.get $1
+    i32.load
+    i32.const -4
+    i32.and
+    i32.add
+    local.tee $4
+    i32.load
+    local.set $5
+   end
+  end
+  local.get $3
+  i32.const 2
+  i32.and
+  if
+   local.get $1
+   i32.const 4
+   i32.sub
+   i32.load
+   local.tee $2
+   i32.load
+   local.tee $6
+   i32.const -4
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $3
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $7
+   i32.const 1073741808
+   i32.lt_u
+   if
+    local.get $0
+    local.get $2
+    call $~lib/rt/tlsf/removeBlock
+    local.get $2
+    local.get $6
+    i32.const 3
+    i32.and
+    local.get $7
+    i32.or
+    local.tee $3
+    i32.store
+    local.get $2
+    local.set $1
+   end
+  end
+  local.get $4
+  local.get $5
+  i32.const 2
+  i32.or
+  i32.store
+  local.get $4
+  i32.const 4
+  i32.sub
+  local.get $1
+  i32.store
+  local.get $3
+  i32.const -4
+  i32.and
+  local.tee $2
+  i32.const 256
+  i32.lt_u
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shr_u
+   local.set $4
+   i32.const 0
+  else   
+   local.get $2
+   i32.const 31
+   local.get $2
+   i32.clz
+   i32.sub
+   local.tee $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $4
+   local.get $2
+   i32.const 7
+   i32.sub
+  end
+  local.set $3
+  local.get $3
+  i32.const 4
+  i32.shl
+  local.get $4
+  i32.add
+  i32.const 2
+  i32.shl
+  local.get $0
+  i32.add
+  i32.load offset=96
+  local.set $2
+  local.get $1
+  i32.const 0
+  i32.store offset=16
+  local.get $1
+  local.get $2
+  i32.store offset=20
+  local.get $2
+  if
+   local.get $2
+   local.get $1
+   i32.store offset=16
+  end
+  local.get $3
+  i32.const 4
+  i32.shl
+  local.get $4
+  i32.add
+  i32.const 2
+  i32.shl
+  local.get $0
+  i32.add
+  local.get $1
+  i32.store offset=96
+  local.get $0
+  local.get $0
+  i32.load
+  i32.const 1
+  local.get $3
+  i32.shl
+  i32.or
+  i32.store
+  local.get $3
+  i32.const 2
+  i32.shl
+  local.get $0
+  i32.add
+  local.get $3
+  i32.const 2
+  i32.shl
+  local.get $0
+  i32.add
+  i32.load offset=4
+  i32.const 1
+  local.get $4
+  i32.shl
+  i32.or
+  i32.store offset=4
+ )
+ (func $~lib/rt/tlsf/addMemory (; 3 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $2
+  local.get $0
+  i32.load offset=1568
+  local.tee $2
+  if
+   local.get $1
+   i32.const 16
+   i32.sub
+   local.get $2
+   i32.eq
+   if
+    local.get $2
+    i32.load
+    local.set $3
+    local.get $1
+    i32.const 16
+    i32.sub
+    local.set $1
+   end
+  end
+  local.get $1
+  i32.sub
+  local.tee $2
+  i32.const 48
+  i32.lt_u
+  if
+   return
+  end
+  local.get $1
+  local.get $3
+  i32.const 2
+  i32.and
+  local.get $2
+  i32.const 32
+  i32.sub
+  i32.const 1
+  i32.or
+  i32.or
+  i32.store
+  local.get $1
+  i32.const 0
+  i32.store offset=16
+  local.get $1
+  i32.const 0
+  i32.store offset=20
+  local.get $1
+  local.get $2
+  i32.add
+  i32.const 16
+  i32.sub
+  local.tee $2
+  i32.const 2
+  i32.store
+  local.get $0
+  local.get $2
+  i32.store offset=1568
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+ )
+ (func $~lib/rt/tlsf/initializeRoot (; 4 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 1
+  memory.size
+  local.tee $0
+  i32.gt_s
+  if (result i32)
+   i32.const 1
+   local.get $0
+   i32.sub
+   memory.grow
+   i32.const 0
+   i32.lt_s
+  else   
+   i32.const 0
+  end
+  if
+   unreachable
+  end
+  i32.const 832
+  i32.const 0
+  i32.store
+  i32.const 2400
+  i32.const 0
+  i32.store
+  i32.const 0
+  local.set $0
+  loop $loop|0
+   block $break|0
+    local.get $0
+    i32.const 23
+    i32.ge_u
+    br_if $break|0
+    local.get $0
+    i32.const 2
+    i32.shl
+    i32.const 832
+    i32.add
     i32.const 0
-    local.set $4
+    i32.store offset=4
+    i32.const 0
+    local.set $1
     loop $loop|1
-     local.get $4
-     i32.const 16
-     i32.lt_u
-     if
-      local.get $4
-      i32.const 2
-      i32.shl
-      local.tee $14
-      local.get $2
-      i32.add
-      local.set $5
-      local.get $0
-      local.get $14
-      i32.add
-      local.get $5
-      i32.const 3
-      i32.add
+     block $break|1
       local.get $1
-      i32.add
-      i32.load8_u
-      local.get $1
-      local.get $5
-      i32.add
-      i32.load8_u
-      i32.const 24
-      i32.shl
-      local.get $5
-      i32.const 1
-      i32.add
-      local.get $1
-      i32.add
-      i32.load8_u
       i32.const 16
+      i32.ge_u
+      br_if $break|1
+      local.get $0
+      i32.const 4
       i32.shl
-      i32.or
-      local.get $5
-      i32.const 2
-      i32.add
       local.get $1
       i32.add
-      i32.load8_u
-      i32.const 8
+      i32.const 2
       i32.shl
-      i32.or
-      i32.or
-      i32.store
-      local.get $4
+      i32.const 832
+      i32.add
+      i32.const 0
+      i32.store offset=96
+      local.get $1
       i32.const 1
       i32.add
-      local.set $4
+      local.set $1
       br $loop|1
      end
     end
-    i32.const 16
-    local.set $4
-    loop $loop|2
-     local.get $4
-     i32.const 64
-     i32.lt_u
-     if
-      local.get $4
-      i32.const 2
-      i32.shl
-      local.get $0
-      i32.add
-      local.get $4
-      i32.const 16
-      i32.sub
-      i32.const 2
-      i32.shl
-      local.get $0
-      i32.add
-      i32.load
-      local.get $4
-      i32.const 15
-      i32.sub
-      i32.const 2
-      i32.shl
-      local.get $0
-      i32.add
-      i32.load
-      local.tee $5
-      i32.const 7
-      i32.rotr
-      local.get $5
-      i32.const 18
-      i32.rotr
-      i32.xor
-      local.get $5
-      i32.const 3
-      i32.shr_u
-      i32.xor
-      local.get $4
-      i32.const 7
-      i32.sub
-      i32.const 2
-      i32.shl
-      local.get $0
-      i32.add
-      i32.load
-      local.get $4
-      i32.const 2
-      i32.sub
-      i32.const 2
-      i32.shl
-      local.get $0
-      i32.add
-      i32.load
-      local.tee $5
-      i32.const 17
-      i32.rotr
-      local.get $5
-      i32.const 19
-      i32.rotr
-      i32.xor
-      local.get $5
-      i32.const 10
-      i32.shr_u
-      i32.xor
-      i32.add
-      i32.add
-      i32.add
-      i32.store
-      local.get $4
-      i32.const 1
-      i32.add
-      local.set $4
-      br $loop|2
-     end
-    end
-    i32.const 0
-    local.set $4
-    loop $loop|3
-     local.get $4
-     i32.const 64
-     i32.lt_u
-     if
-      local.get $4
-      i32.const 2
-      i32.shl
-      local.tee $5
-      local.get $0
-      i32.add
-      i32.load
-      local.get $5
-      local.get $15
-      i32.add
-      i32.load
-      local.get $7
-      i32.const 6
-      i32.rotr
-      local.get $7
-      i32.const 11
-      i32.rotr
-      i32.xor
-      local.get $7
-      i32.const 25
-      i32.rotr
-      i32.xor
-      local.get $7
-      local.get $10
-      i32.and
-      local.get $7
-      i32.const -1
-      i32.xor
-      local.get $11
-      i32.and
-      i32.xor
-      i32.add
-      local.get $13
-      i32.add
-      i32.add
-      i32.add
-      local.set $5
-      local.get $6
-      i32.const 2
-      i32.rotr
-      local.get $6
-      i32.const 13
-      i32.rotr
-      i32.xor
-      local.get $6
-      i32.const 22
-      i32.rotr
-      i32.xor
-      local.get $8
-      local.get $9
-      i32.and
-      local.get $6
-      local.get $8
-      i32.and
-      local.get $6
-      local.get $9
-      i32.and
-      i32.xor
-      i32.xor
-      i32.add
-      local.set $14
-      local.get $11
-      local.set $13
-      local.get $10
-      local.set $11
-      local.get $7
-      local.set $10
-      local.get $5
-      local.get $12
-      i32.add
-      local.set $7
-      local.get $9
-      local.set $12
-      local.get $8
-      local.set $9
-      local.get $6
-      local.set $8
-      local.get $5
-      local.get $14
-      i32.add
-      local.set $6
-      local.get $4
-      i32.const 1
-      i32.add
-      local.set $4
-      br $loop|3
-     end
-    end
-    global.get $assembly/index/H0
-    local.get $6
+    local.get $0
+    i32.const 1
     i32.add
-    global.set $assembly/index/H0
-    global.get $assembly/index/H1
-    local.get $8
-    i32.add
-    global.set $assembly/index/H1
-    global.get $assembly/index/H2
-    local.get $9
-    i32.add
-    global.set $assembly/index/H2
-    global.get $assembly/index/H3
-    local.get $12
-    i32.add
-    global.set $assembly/index/H3
-    global.get $assembly/index/H4
-    local.get $7
-    i32.add
-    global.set $assembly/index/H4
-    global.get $assembly/index/H5
-    local.get $10
-    i32.add
-    global.set $assembly/index/H5
-    global.get $assembly/index/H6
-    local.get $11
-    i32.add
-    global.set $assembly/index/H6
-    global.get $assembly/index/H7
-    local.get $13
-    i32.add
-    global.set $assembly/index/H7
-    local.get $2
-    i32.const -64
-    i32.sub
-    local.set $2
-    local.get $3
-    i32.const -64
-    i32.add
-    local.set $3
-    br $continue|0
+    local.set $0
+    br $loop|0
    end
   end
+  i32.const 832
+  i32.const 2416
+  memory.size
+  i32.const 16
+  i32.shl
+  call $~lib/rt/tlsf/addMemory
+  i32.const 832
+  global.set $~lib/rt/tlsf/ROOT
+ )
+ (func $~lib/rt/tlsf/prepareSize (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 1073741808
+  i32.ge_u
+  if
+   i32.const 24
+   i32.const 80
+   i32.const 457
+   i32.const 29
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const -16
+  i32.and
+  local.tee $0
+  i32.const 16
+  local.get $0
+  i32.const 16
+  i32.gt_u
+  select
+ )
+ (func $~lib/rt/tlsf/searchBlock (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 256
+  i32.lt_u
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shr_u
+   local.set $1
+   i32.const 0
+  else   
+   local.get $1
+   i32.const 536870904
+   i32.lt_u
+   if
+    i32.const 1
+    i32.const 27
+    local.get $1
+    i32.clz
+    i32.sub
+    i32.shl
+    local.get $1
+    i32.add
+    i32.const 1
+    i32.sub
+    local.set $1
+   end
+   local.get $1
+   i32.const 31
+   local.get $1
+   i32.clz
+   i32.sub
+   local.tee $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $1
+   local.get $2
+   i32.const 7
+   i32.sub
+  end
+  local.tee $2
+  i32.const 2
+  i32.shl
+  local.get $0
+  i32.add
+  i32.load offset=4
+  i32.const -1
+  local.get $1
+  i32.shl
+  i32.and
+  local.tee $1
+  if (result i32)
+   local.get $1
+   i32.ctz
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.add
+   i32.const 2
+   i32.shl
+   local.get $0
+   i32.add
+   i32.load offset=96
+  else   
+   local.get $0
+   i32.load
+   i32.const -1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.shl
+   i32.and
+   local.tee $1
+   if (result i32)
+    local.get $0
+    local.get $0
+    local.get $1
+    i32.ctz
+    local.tee $0
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    i32.ctz
+    local.get $0
+    i32.const 4
+    i32.shl
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=96
+   else    
+    i32.const 0
+   end
+  end
+ )
+ (func $~lib/rt/tlsf/growMemory (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  memory.size
+  local.tee $2
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if (result i32)
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   local.get $1
+   i32.add
+  else   
+   local.get $1
+  end
+  i32.const 16
+  local.get $0
+  i32.load offset=1568
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  i32.ne
+  i32.shl
+  i32.add
+  i32.const 65535
+  i32.add
+  i32.const -65536
+  i32.and
+  i32.const 16
+  i32.shr_u
+  local.tee $1
+  local.get $2
+  local.get $1
+  i32.gt_s
+  select
+  memory.grow
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $1
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    unreachable
+   end
+  end
+  local.get $0
+  local.get $2
+  i32.const 16
+  i32.shl
+  memory.size
+  i32.const 16
+  i32.shl
+  call $~lib/rt/tlsf/addMemory
+ )
+ (func $~lib/rt/tlsf/prepareBlock (; 8 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  local.get $1
+  i32.load
+  local.tee $3
+  i32.const -4
+  i32.and
+  local.get $2
+  i32.sub
+  local.tee $4
+  i32.const 32
+  i32.ge_u
+  if
+   local.get $1
+   local.get $3
+   i32.const 2
+   i32.and
+   local.get $2
+   i32.or
+   i32.store
+   local.get $1
+   i32.const 16
+   i32.add
+   local.get $2
+   i32.add
+   local.tee $1
+   local.get $4
+   i32.const 16
+   i32.sub
+   i32.const 1
+   i32.or
+   i32.store
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/insertBlock
+  else   
+   local.get $1
+   local.get $3
+   i32.const -2
+   i32.and
+   i32.store
+   local.get $1
+   i32.const 16
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.get $1
+   i32.const 16
+   i32.add
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   i32.load
+   i32.const -3
+   i32.and
+   i32.store
+  end
+ )
+ (func $~lib/rt/tlsf/allocateBlock (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/prepareSize
+  local.tee $3
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $2
+  i32.eqz
+  if
+   local.get $0
+   local.get $3
+   call $~lib/rt/tlsf/growMemory
+   local.get $0
+   local.get $3
+   call $~lib/rt/tlsf/searchBlock
+   local.set $2
+  end
+  local.get $2
+  i32.const 0
+  i32.store offset=4
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  local.get $0
+  local.get $2
+  call $~lib/rt/tlsf/removeBlock
+  local.get $0
+  local.get $2
+  local.get $3
+  call $~lib/rt/tlsf/prepareBlock
   local.get $2
  )
- (func $~lib/util/memory/memcpy (; 10 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/__alloc (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  global.get $~lib/rt/tlsf/ROOT
+  local.tee $2
+  if (result i32)
+   local.get $2
+  else   
+   call $~lib/rt/tlsf/initializeRoot
+   global.get $~lib/rt/tlsf/ROOT
+  end
+  local.get $0
+  call $~lib/rt/tlsf/allocateBlock
+  local.tee $0
+  local.get $1
+  i32.store offset=8
+  local.get $0
+  i32.const 16
+  i32.add
+ )
+ (func $~lib/rt/pure/__retain (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   local.tee $1
+   local.get $1
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
+  local.get $0
+ )
+ (func $~lib/rt/tlsf/freeBlock (; 12 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  local.get $1
+  local.get $1
+  i32.load
+  i32.const 1
+  i32.or
+  i32.store
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+ )
+ (func $~lib/rt/__typeinfo (; 13 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 784
+  i32.load
+  i32.gt_u
+  if
+   i32.const 128
+   i32.const 184
+   i32.const 22
+   i32.const 27
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 3
+  i32.shl
+  i32.const 788
+  i32.add
+  i32.load
+ )
+ (func $~lib/util/memory/memcpy (; 14 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -1568,7 +1718,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 11 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 15 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   block $~lib/util/memory/memmove|inlined.0
@@ -1762,22 +1912,1079 @@
    end
   end
  )
- (func $assembly/index/update (; 12 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/growRoots (; 16 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/rt/pure/CUR
+  global.get $~lib/rt/pure/ROOTS
+  local.tee $1
+  i32.sub
+  local.tee $2
+  i32.const 1
+  i32.shl
+  local.tee $0
+  i32.const 256
+  local.get $0
+  i32.const 256
+  i32.gt_u
+  select
+  local.tee $3
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $0
+  local.get $1
+  local.get $2
+  call $~lib/memory/memory.copy
+  local.get $1
+  if
+   global.get $~lib/rt/tlsf/ROOT
+   local.get $1
+   i32.const 16
+   i32.sub
+   call $~lib/rt/tlsf/freeBlock
+  end
+  local.get $0
+  global.set $~lib/rt/pure/ROOTS
+  local.get $0
+  local.get $2
+  i32.add
+  global.set $~lib/rt/pure/CUR
+  local.get $0
+  local.get $3
+  i32.add
+  global.set $~lib/rt/pure/END
+ )
+ (func $~lib/rt/pure/appendRoot (; 17 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  global.get $~lib/rt/pure/CUR
+  local.tee $1
+  global.get $~lib/rt/pure/END
+  i32.ge_u
+  if
+   call $~lib/rt/pure/growRoots
+   global.get $~lib/rt/pure/CUR
+   local.set $1
+  end
+  local.get $1
+  local.get $0
+  i32.store
+  local.get $1
+  i32.const 4
+  i32.add
+  global.set $~lib/rt/pure/CUR
+ )
+ (func $~lib/rt/pure/decrement (; 18 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  i32.const 268435455
+  i32.and
+  local.tee $2
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   i32.const 16
+   i32.add
+   i32.const 1
+   call $~lib/rt/__visit_members
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   if
+    local.get $0
+    i32.const -2147483648
+    i32.store offset=4
+   else    
+    global.get $~lib/rt/tlsf/ROOT
+    local.get $0
+    call $~lib/rt/tlsf/freeBlock
+   end
+  else   
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/__typeinfo
+   i32.const 16
+   i32.and
+   if
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.sub
+    local.get $1
+    i32.const -268435456
+    i32.and
+    i32.or
+    i32.store offset=4
+   else    
+    local.get $0
+    local.get $2
+    i32.const 1
+    i32.sub
+    i32.const -1342177280
+    i32.or
+    i32.store offset=4
+    local.get $1
+    i32.const -2147483648
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     call $~lib/rt/pure/appendRoot
+    end
+   end
+  end
+ )
+ (func $~lib/rt/pure/__release (; 19 ;) (type $FUNCSIG$vi) (param $0 i32)
+  local.get $0
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
+ )
+ (func $~lib/rt/pure/markGray (; 20 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  i32.const 1879048192
+  i32.and
+  i32.const 268435456
+  i32.ne
+  if
+   local.get $0
+   local.get $1
+   i32.const -1879048193
+   i32.and
+   i32.const 268435456
+   i32.or
+   i32.store offset=4
+   local.get $0
+   i32.const 16
+   i32.add
+   i32.const 2
+   call $~lib/rt/__visit_members
+  end
+ )
+ (func $~lib/rt/pure/scanBlack (; 21 ;) (type $FUNCSIG$vi) (param $0 i32)
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const -1879048193
+  i32.and
+  i32.store offset=4
+  local.get $0
+  i32.const 16
+  i32.add
+  i32.const 4
+  call $~lib/rt/__visit_members
+ )
+ (func $~lib/rt/pure/scan (; 22 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  i32.const 1879048192
+  i32.and
+  i32.const 268435456
+  i32.eq
+  if
+   local.get $1
+   i32.const 268435455
+   i32.and
+   i32.const 0
+   i32.gt_u
+   if
+    local.get $0
+    call $~lib/rt/pure/scanBlack
+   else    
+    local.get $0
+    local.get $1
+    i32.const -1879048193
+    i32.and
+    i32.const 536870912
+    i32.or
+    i32.store offset=4
+    local.get $0
+    i32.const 16
+    i32.add
+    i32.const 3
+    call $~lib/rt/__visit_members
+   end
+  end
+ )
+ (func $~lib/rt/pure/collectWhite (; 23 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.tee $1
+  i32.const 1879048192
+  i32.and
+  i32.const 536870912
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.eqz
+  else   
+   i32.const 0
+  end
+  if
+   local.get $0
+   local.get $1
+   i32.const -1879048193
+   i32.and
+   i32.store offset=4
+   local.get $0
+   i32.const 16
+   i32.add
+   i32.const 5
+   call $~lib/rt/__visit_members
+   global.get $~lib/rt/tlsf/ROOT
+   local.get $0
+   call $~lib/rt/tlsf/freeBlock
+  end
+ )
+ (func $~lib/rt/pure/__collect (; 24 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  global.get $assembly/index/finished
-  if
-   i32.const 432
-   i32.const 544
-   i32.const 143
+  (local $5 i32)
+  global.get $~lib/rt/pure/ROOTS
+  local.tee $5
+  local.tee $2
+  local.set $3
+  global.get $~lib/rt/pure/CUR
+  local.set $0
+  loop $loop|0
+   block $break|0
+    local.get $3
+    local.get $0
+    i32.ge_u
+    br_if $break|0
+    local.get $3
+    i32.load
+    local.tee $4
+    i32.load offset=4
+    local.tee $1
+    i32.const 1879048192
+    i32.and
+    i32.const 805306368
+    i32.eq
+    if (result i32)
+     local.get $1
+     i32.const 268435455
+     i32.and
+     i32.const 0
+     i32.gt_u
+    else     
+     i32.const 0
+    end
+    if
+     local.get $4
+     call $~lib/rt/pure/markGray
+     local.get $2
+     local.get $4
+     i32.store
+     local.get $2
+     i32.const 4
+     i32.add
+     local.set $2
+    else     
+     i32.const 0
+     local.get $1
+     i32.const 268435455
+     i32.and
+     i32.eqz
+     local.get $1
+     i32.const 1879048192
+     i32.and
+     select
+     if
+      global.get $~lib/rt/tlsf/ROOT
+      local.get $4
+      call $~lib/rt/tlsf/freeBlock
+     else      
+      local.get $4
+      local.get $1
+      i32.const 2147483647
+      i32.and
+      i32.store offset=4
+     end
+    end
+    local.get $3
+    i32.const 4
+    i32.add
+    local.set $3
+    br $loop|0
+   end
+  end
+  local.get $2
+  global.set $~lib/rt/pure/CUR
+  local.get $5
+  local.set $0
+  loop $loop|1
+   block $break|1
+    local.get $0
+    local.get $2
+    i32.ge_u
+    br_if $break|1
+    local.get $0
+    i32.load
+    call $~lib/rt/pure/scan
+    local.get $0
+    i32.const 4
+    i32.add
+    local.set $0
+    br $loop|1
+   end
+  end
+  local.get $5
+  local.set $0
+  loop $loop|2
+   block $break|2
+    local.get $0
+    local.get $2
+    i32.ge_u
+    br_if $break|2
+    local.get $0
+    i32.load
+    local.tee $1
+    local.get $1
+    i32.load offset=4
+    i32.const 2147483647
+    i32.and
+    i32.store offset=4
+    local.get $1
+    call $~lib/rt/pure/collectWhite
+    local.get $0
+    i32.const 4
+    i32.add
+    local.set $0
+    br $loop|2
+   end
+  end
+  local.get $5
+  global.set $~lib/rt/pure/CUR
+ )
+ (func $~lib/memory/memory.fill (; 25 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  block $~lib/util/memory/memset|inlined.0
+   local.get $1
+   i32.eqz
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 0
+   i32.store8
+   local.get $0
+   local.get $1
+   i32.add
+   i32.const 1
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $1
+   i32.const 2
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 1
+   i32.add
+   i32.const 0
+   i32.store8
+   local.get $0
+   i32.const 2
+   i32.add
+   i32.const 0
+   i32.store8
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 2
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $2
+   i32.const 3
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $1
+   i32.const 6
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 3
+   i32.add
+   i32.const 0
+   i32.store8
+   local.get $0
+   local.get $1
+   i32.add
    i32.const 4
+   i32.sub
+   i32.const 0
+   i32.store8
+   local.get $1
+   i32.const 8
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $1
+   i32.const 0
+   local.get $0
+   i32.sub
+   i32.const 3
+   i32.and
+   local.tee $1
+   i32.sub
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $0
+   i32.const 0
+   i32.store
+   i32.const -4
+   i32.and
+   local.tee $1
+   local.get $0
+   i32.add
+   i32.const 4
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
+   i32.const 8
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 4
+   i32.add
+   i32.const 0
+   i32.store
+   local.get $0
+   i32.const 8
+   i32.add
+   i32.const 0
+   i32.store
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 12
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $2
+   i32.const 8
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $1
+   i32.const 24
+   i32.le_u
+   br_if $~lib/util/memory/memset|inlined.0
+   local.get $0
+   i32.const 12
+   i32.add
+   i32.const 0
+   i32.store
+   local.get $0
+   i32.const 16
+   i32.add
+   i32.const 0
+   i32.store
+   local.get $0
+   i32.const 20
+   i32.add
+   i32.const 0
+   i32.store
+   local.get $0
+   i32.const 24
+   i32.add
+   i32.const 0
+   i32.store
+   local.get $0
+   local.get $1
+   i32.add
+   local.tee $2
+   i32.const 28
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $2
+   i32.const 24
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $2
+   i32.const 20
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $2
+   i32.const 16
+   i32.sub
+   i32.const 0
+   i32.store
+   local.get $0
+   i32.const 4
+   i32.and
+   i32.const 24
+   i32.add
+   local.tee $2
+   local.get $0
+   i32.add
+   local.set $0
+   local.get $1
+   local.get $2
+   i32.sub
+   local.set $1
+   loop $continue|0
+    local.get $1
+    i32.const 32
+    i32.ge_u
+    if
+     local.get $0
+     i64.const 0
+     i64.store
+     local.get $0
+     i32.const 8
+     i32.add
+     i64.const 0
+     i64.store
+     local.get $0
+     i32.const 16
+     i32.add
+     i64.const 0
+     i64.store
+     local.get $0
+     i32.const 24
+     i32.add
+     i64.const 0
+     i64.store
+     local.get $1
+     i32.const 32
+     i32.sub
+     local.set $1
+     local.get $0
+     i32.const 32
+     i32.add
+     local.set $0
+     br $continue|0
+    end
+   end
+  end
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 26 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  local.get $0
+  i32.const 1073741808
+  i32.gt_u
+  if
+   i32.const 528
+   i32.const 576
+   i32.const 57
+   i32.const 42
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.tee $1
+  local.get $0
+  call $~lib/memory/memory.fill
+  local.get $1
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 16
+   i32.sub
+   local.tee $0
+   local.get $0
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
+  local.get $1
+ )
+ (func $assembly/index/reset (; 27 ;) (type $FUNCSIG$v)
+  i32.const 1779033703
+  global.set $assembly/index/H0
+  i32.const -1150833019
+  global.set $assembly/index/H1
+  i32.const 1013904242
+  global.set $assembly/index/H2
+  i32.const -1521486534
+  global.set $assembly/index/H3
+  i32.const 1359893119
+  global.set $assembly/index/H4
+  i32.const -1694144372
+  global.set $assembly/index/H5
+  i32.const 528734635
+  global.set $assembly/index/H6
+  i32.const 1541459225
+  global.set $assembly/index/H7
+  i32.const 0
+  global.set $assembly/index/bufferLength
+  i32.const 0
+  global.set $assembly/index/bytesHashed
+  i32.const 0
+  global.set $assembly/index/finished
+ )
+ (func $assembly/index/clean (; 28 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  global.get $assembly/index/buffer
+  local.tee $0
+  i32.const 16
+  i32.sub
+  i32.load offset=12
+  local.set $1
+  local.get $0
+  local.get $1
+  call $~lib/memory/memory.fill
+  global.get $assembly/index/temp
+  local.tee $0
+  i32.const 16
+  i32.sub
+  i32.load offset=12
+  local.set $1
+  local.get $0
+  local.get $1
+  call $~lib/memory/memory.fill
+  call $assembly/index/reset
+ )
+ (func $assembly/index/hashBlocks (; 29 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  local.get $0
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   local.tee $6
+   local.get $6
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
+  local.get $1
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 16
+   i32.sub
+   local.tee $6
+   local.get $6
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
+  i32.const 500
   i32.load
+  local.set $15
+  local.get $1
+  local.set $11
+  local.get $0
+  local.set $7
+  loop $continue|0
+   local.get $3
+   i32.const 64
+   i32.ge_u
+   if
+    global.get $assembly/index/H0
+    local.set $8
+    global.get $assembly/index/H1
+    local.set $12
+    global.get $assembly/index/H2
+    local.set $6
+    global.get $assembly/index/H3
+    local.set $13
+    global.get $assembly/index/H4
+    local.set $9
+    global.get $assembly/index/H5
+    local.set $1
+    global.get $assembly/index/H6
+    local.set $0
+    global.get $assembly/index/H7
+    local.set $14
+    i32.const 0
+    local.set $4
+    loop $loop|1
+     local.get $4
+     i32.const 16
+     i32.lt_u
+     if
+      local.get $4
+      i32.const 2
+      i32.shl
+      local.tee $5
+      local.get $2
+      i32.add
+      local.set $10
+      local.get $5
+      local.get $7
+      i32.add
+      local.get $10
+      i32.const 3
+      i32.add
+      local.get $11
+      i32.add
+      i32.load8_u
+      local.get $10
+      local.get $11
+      i32.add
+      i32.load8_u
+      i32.const 24
+      i32.shl
+      local.get $10
+      i32.const 1
+      i32.add
+      local.get $11
+      i32.add
+      i32.load8_u
+      i32.const 16
+      i32.shl
+      i32.or
+      local.get $10
+      i32.const 2
+      i32.add
+      local.get $11
+      i32.add
+      i32.load8_u
+      i32.const 8
+      i32.shl
+      i32.or
+      i32.or
+      i32.store
+      local.get $4
+      i32.const 1
+      i32.add
+      local.set $4
+      br $loop|1
+     end
+    end
+    i32.const 16
+    local.set $4
+    loop $loop|2
+     local.get $4
+     i32.const 64
+     i32.lt_u
+     if
+      local.get $4
+      i32.const 2
+      i32.shl
+      local.get $7
+      i32.add
+      local.get $4
+      i32.const 16
+      i32.sub
+      i32.const 2
+      i32.shl
+      local.get $7
+      i32.add
+      i32.load
+      local.get $4
+      i32.const 15
+      i32.sub
+      i32.const 2
+      i32.shl
+      local.get $7
+      i32.add
+      i32.load
+      local.tee $5
+      i32.const 7
+      i32.rotr
+      local.get $5
+      i32.const 18
+      i32.rotr
+      i32.xor
+      local.get $5
+      i32.const 3
+      i32.shr_u
+      i32.xor
+      local.get $4
+      i32.const 7
+      i32.sub
+      i32.const 2
+      i32.shl
+      local.get $7
+      i32.add
+      i32.load
+      local.get $4
+      i32.const 2
+      i32.sub
+      i32.const 2
+      i32.shl
+      local.get $7
+      i32.add
+      i32.load
+      local.tee $5
+      i32.const 17
+      i32.rotr
+      local.get $5
+      i32.const 19
+      i32.rotr
+      i32.xor
+      local.get $5
+      i32.const 10
+      i32.shr_u
+      i32.xor
+      i32.add
+      i32.add
+      i32.add
+      i32.store
+      local.get $4
+      i32.const 1
+      i32.add
+      local.set $4
+      br $loop|2
+     end
+    end
+    i32.const 0
+    local.set $4
+    loop $loop|3
+     local.get $4
+     i32.const 64
+     i32.lt_u
+     if
+      local.get $4
+      i32.const 2
+      i32.shl
+      local.tee $5
+      local.get $7
+      i32.add
+      i32.load
+      local.get $5
+      local.get $15
+      i32.add
+      i32.load
+      local.get $9
+      i32.const 6
+      i32.rotr
+      local.get $9
+      i32.const 11
+      i32.rotr
+      i32.xor
+      local.get $9
+      i32.const 25
+      i32.rotr
+      i32.xor
+      local.get $1
+      local.get $9
+      i32.and
+      local.get $9
+      i32.const -1
+      i32.xor
+      local.get $0
+      i32.and
+      i32.xor
+      i32.add
+      local.get $14
+      i32.add
+      i32.add
+      i32.add
+      local.set $10
+      local.get $8
+      i32.const 2
+      i32.rotr
+      local.get $8
+      i32.const 13
+      i32.rotr
+      i32.xor
+      local.get $8
+      i32.const 22
+      i32.rotr
+      i32.xor
+      local.get $6
+      local.get $12
+      i32.and
+      local.get $8
+      local.get $12
+      i32.and
+      local.get $6
+      local.get $8
+      i32.and
+      i32.xor
+      i32.xor
+      i32.add
+      local.get $0
+      local.set $14
+      local.get $1
+      local.set $0
+      local.get $9
+      local.set $1
+      local.get $10
+      local.get $13
+      i32.add
+      local.set $9
+      local.get $6
+      local.set $13
+      local.get $12
+      local.set $6
+      local.get $8
+      local.set $12
+      local.get $10
+      i32.add
+      local.set $8
+      local.get $4
+      i32.const 1
+      i32.add
+      local.set $4
+      br $loop|3
+     end
+    end
+    global.get $assembly/index/H0
+    local.get $8
+    i32.add
+    global.set $assembly/index/H0
+    global.get $assembly/index/H1
+    local.get $12
+    i32.add
+    global.set $assembly/index/H1
+    global.get $assembly/index/H2
+    local.get $6
+    i32.add
+    global.set $assembly/index/H2
+    global.get $assembly/index/H3
+    local.get $13
+    i32.add
+    global.set $assembly/index/H3
+    global.get $assembly/index/H4
+    local.get $9
+    i32.add
+    global.set $assembly/index/H4
+    global.get $assembly/index/H5
+    local.get $1
+    i32.add
+    global.set $assembly/index/H5
+    global.get $assembly/index/H6
+    local.get $0
+    i32.add
+    global.set $assembly/index/H6
+    global.get $assembly/index/H7
+    local.get $14
+    i32.add
+    global.set $assembly/index/H7
+    local.get $2
+    i32.const -64
+    i32.sub
+    local.set $2
+    local.get $3
+    i32.const -64
+    i32.add
+    local.set $3
+    br $continue|0
+   end
+  end
+  local.get $7
+  call $~lib/rt/pure/__release
+  local.get $11
+  call $~lib/rt/pure/__release
+  local.get $2
+ )
+ (func $assembly/index/update (; 30 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  local.get $0
+  local.tee $2
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $2
+   i32.const 16
+   i32.sub
+   local.tee $0
+   local.get $0
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
+  global.get $assembly/index/finished
+  if
+   local.get $2
+   call $~lib/rt/pure/__release
+   i32.const 632
+   i32.const 744
+   i32.const 145
+   i32.const 4
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.load
+  local.tee $5
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $5
+   i32.const 16
+   i32.sub
+   local.tee $0
+   local.get $0
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
+  local.get $5
+  local.tee $0
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   local.tee $3
+   local.get $3
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
+  local.get $0
   local.set $3
+  local.get $2
+  i32.load offset=4
+  local.set $6
+  global.get $assembly/index/buffer
+  local.set $7
   global.get $assembly/index/bytesHashed
   local.get $1
   i32.add
@@ -1797,20 +3004,20 @@
     select
     if
      global.get $assembly/index/bufferLength
-     local.tee $4
+     local.tee $8
      i32.const 1
      i32.add
      global.set $assembly/index/bufferLength
-     local.get $2
+     local.get $4
      local.tee $0
      i32.const 1
      i32.add
-     local.set $2
-     global.get $assembly/index/buffer
-     local.get $4
+     local.set $4
+     local.get $7
+     local.get $8
      i32.add
      local.get $0
-     local.get $3
+     local.get $6
      i32.add
      i32.load8_u
      i32.store8
@@ -1841,18 +3048,18 @@
   if
    global.get $assembly/index/temp
    local.get $3
-   local.get $2
+   local.get $4
    local.get $1
    call $assembly/index/hashBlocks
-   local.set $2
+   local.set $4
    local.get $1
    i32.const 63
    i32.and
    local.set $1
   end
-  global.get $assembly/index/buffer
-  local.get $2
-  local.get $3
+  local.get $7
+  local.get $4
+  local.get $6
   i32.add
   local.get $1
   call $~lib/memory/memory.copy
@@ -1860,13 +3067,34 @@
   local.get $1
   i32.add
   global.set $assembly/index/bufferLength
+  local.get $5
+  call $~lib/rt/pure/__release
+  local.get $3
+  call $~lib/rt/pure/__release
+  local.get $2
+  call $~lib/rt/pure/__release
  )
- (func $assembly/index/finish (; 13 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $assembly/index/finish (; 31 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   local.tee $1
+   local.get $1
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
   global.get $assembly/index/finished
   i32.eqz
   if
@@ -1874,14 +3102,15 @@
    local.tee $2
    i32.const 536870912
    i32.div_s
-   local.set $3
+   local.set $4
    local.get $2
    i32.const 3
    i32.shl
-   local.set $4
+   local.set $5
+   global.get $assembly/index/buffer
+   local.tee $3
    global.get $assembly/index/bufferLength
    local.tee $1
-   global.get $assembly/index/buffer
    i32.add
    i32.const 128
    i32.store8
@@ -1899,14 +3128,14 @@
    local.tee $2
    i32.const 8
    i32.sub
-   local.set $5
+   local.set $6
    loop $loop|0
     local.get $1
-    local.get $5
+    local.get $6
     i32.lt_s
     if
-     global.get $assembly/index/buffer
      local.get $1
+     local.get $3
      i32.add
      i32.const 0
      i32.store8
@@ -1917,7 +3146,6 @@
      br $loop|0
     end
    end
-   global.get $assembly/index/buffer
    local.get $2
    i32.const 8
    i32.sub
@@ -1925,20 +3153,20 @@
    i32.shr_s
    i32.const 2
    i32.shl
-   i32.add
    local.get $3
+   i32.add
+   local.get $4
    i32.const -16711936
    i32.and
    i32.const 8
    i32.rotl
-   local.get $3
+   local.get $4
    i32.const 16711935
    i32.and
    i32.const 8
    i32.rotr
    i32.or
    i32.store
-   global.get $assembly/index/buffer
    local.get $2
    i32.const 4
    i32.sub
@@ -1946,13 +3174,14 @@
    i32.shr_s
    i32.const 2
    i32.shl
+   local.get $3
    i32.add
-   local.get $4
+   local.get $5
    i32.const -16711936
    i32.and
    i32.const 8
    i32.rotl
-   local.get $4
+   local.get $5
    i32.const 16711935
    i32.and
    i32.const 8
@@ -2082,24 +3311,28 @@
   i32.const 28
   i32.add
   global.get $assembly/index/H7
-  local.tee $0
+  local.tee $1
   i32.const -16711936
   i32.and
   i32.const 8
   i32.rotl
-  local.get $0
+  local.get $1
   i32.const 16711935
   i32.and
   i32.const 8
   i32.rotr
   i32.or
   i32.store
+  local.get $0
+  call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 32 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   i32.const 32
   i32.const 0
-  call $~lib/rt/stub/__alloc
+  call $~lib/rt/tlsf/__alloc
   local.tee $1
   i32.const 32
   call $~lib/memory/memory.fill
@@ -2108,8 +3341,21 @@
   if
    i32.const 12
    i32.const 2
-   call $~lib/rt/stub/__alloc
-   local.set $0
+   call $~lib/rt/tlsf/__alloc
+   local.tee $0
+   i32.const 828
+   i32.gt_u
+   if
+    local.get $0
+    i32.const 16
+    i32.sub
+    local.tee $2
+    local.get $2
+    i32.load offset=4
+    i32.const 1
+    i32.add
+    i32.store offset=4
+   end
   end
   local.get $0
   i32.const 0
@@ -2122,7 +3368,27 @@
   i32.store offset=8
   local.get $0
   i32.load
-  drop
+  local.tee $2
+  local.get $1
+  i32.ne
+  if
+   local.get $1
+   i32.const 828
+   i32.gt_u
+   if
+    local.get $1
+    i32.const 16
+    i32.sub
+    local.tee $3
+    local.get $3
+    i32.load offset=4
+    i32.const 1
+    i32.add
+    i32.store offset=4
+   end
+   local.get $2
+   call $~lib/rt/pure/__release
+  end
   local.get $0
   local.get $1
   i32.store
@@ -2134,7 +3400,23 @@
   i32.store offset=8
   local.get $0
  )
- (func $assembly/index/hashMe (; 15 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/index/hashMe (; 33 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   local.tee $1
+   local.get $1
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
   call $assembly/index/reset
   local.get $0
   local.get $0
@@ -2144,20 +3426,33 @@
   call $assembly/index/finish
   i32.const 12
   i32.const 3
-  call $~lib/rt/stub/__alloc
+  call $~lib/rt/tlsf/__alloc
+  local.tee $1
+  i32.const 828
+  i32.gt_u
+  if
+   local.get $1
+   i32.const 16
+   i32.sub
+   local.tee $2
+   local.get $2
+   i32.load offset=4
+   i32.const 1
+   i32.add
+   i32.store offset=4
+  end
+  local.get $1
   call $~lib/arraybuffer/ArrayBufferView#constructor
-  local.tee $0
+  local.tee $1
   i32.load offset=4
   global.get $assembly/index/out
   i32.const 32
   call $~lib/memory/memory.copy
   local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
  )
- (func $start (; 16 ;) (type $FUNCSIG$v)
-  i32.const 640
-  global.set $~lib/rt/stub/startOffset
-  global.get $~lib/rt/stub/startOffset
-  global.set $~lib/rt/stub/offset
+ (func $start (; 34 ;) (type $FUNCSIG$v)
   i32.const 256
   call $~lib/arraybuffer/ArrayBuffer#constructor
   global.set $assembly/index/temp
@@ -2167,5 +3462,101 @@
   i32.const 32
   call $~lib/arraybuffer/ArrayBuffer#constructor
   global.set $assembly/index/out
+ )
+ (func $~lib/rt/pure/__visit (; 35 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  local.get $0
+  i32.const 828
+  i32.lt_u
+  if
+   return
+  end
+  local.get $0
+  i32.const 16
+  i32.sub
+  local.set $0
+  block $break|0
+   block $case4|0
+    block $case3|0
+     block $case2|0
+      block $case1|0
+       local.get $1
+       i32.const 1
+       i32.ne
+       if
+        local.get $1
+        i32.const 2
+        i32.eq
+        br_if $case1|0
+        block $tablify|0
+         local.get $1
+         i32.const 3
+         i32.sub
+         br_table $case2|0 $case3|0 $case4|0 $tablify|0
+        end
+        br $break|0
+       end
+       local.get $0
+       call $~lib/rt/pure/decrement
+       br $break|0
+      end
+      local.get $0
+      local.get $0
+      i32.load offset=4
+      i32.const 1
+      i32.sub
+      i32.store offset=4
+      local.get $0
+      call $~lib/rt/pure/markGray
+      br $break|0
+     end
+     local.get $0
+     call $~lib/rt/pure/scan
+     br $break|0
+    end
+    local.get $0
+    local.get $0
+    i32.load offset=4
+    local.tee $1
+    i32.const 1
+    i32.add
+    i32.store offset=4
+    local.get $1
+    i32.const 1879048192
+    i32.and
+    if
+     local.get $0
+     call $~lib/rt/pure/scanBlack
+    end
+    br $break|0
+   end
+   local.get $0
+   call $~lib/rt/pure/collectWhite
+  end
+ )
+ (func $~lib/rt/__visit_members (; 36 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  block $block$4$break
+   block $switch$1$default
+    block $switch$1$case$2
+     local.get $0
+     i32.const 8
+     i32.sub
+     i32.load
+     br_table $switch$1$case$2 $switch$1$case$2 $block$4$break $block$4$break $block$4$break $switch$1$default
+    end
+    return
+   end
+   unreachable
+  end
+  local.get $0
+  i32.load
+  local.tee $0
+  if
+   local.get $0
+   local.get $1
+   call $~lib/rt/pure/__visit
+  end
+ )
+ (func $null (; 37 ;) (type $FUNCSIG$v)
+  nop
  )
 )

--- a/build/optimized.wat
+++ b/build/optimized.wat
@@ -34,8 +34,8 @@
  (global $assembly/index/H5 (mut i32) (i32.const 0))
  (global $assembly/index/H6 (mut i32) (i32.const 0))
  (global $assembly/index/H7 (mut i32) (i32.const 0))
- (global $assembly/index/temp (mut i32) (i32.const 0))
  (global $assembly/index/buffer (mut i32) (i32.const 0))
+ (global $assembly/index/temp (mut i32) (i32.const 0))
  (global $assembly/index/out (mut i32) (i32.const 0))
  (global $assembly/index/bufferLength (mut i32) (i32.const 0))
  (global $assembly/index/bytesHashed (mut i32) (i32.const 0))
@@ -2567,6 +2567,15 @@
   local.get $0
   local.get $1
   call $~lib/memory/memory.fill
+  global.get $assembly/index/out
+  local.tee $0
+  i32.const 16
+  i32.sub
+  i32.load offset=12
+  local.set $1
+  local.get $0
+  local.get $1
+  call $~lib/memory/memory.fill
   call $assembly/index/reset
  )
  (func $assembly/index/hashBlocks (; 29 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
@@ -2891,14 +2900,12 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
-  (local $8 i32)
-  (local $9 i32)
   local.get $0
-  local.tee $3
+  local.tee $2
   i32.const 828
   i32.gt_u
   if
-   local.get $3
+   local.get $2
    i32.const 16
    i32.sub
    local.tee $0
@@ -2910,55 +2917,22 @@
   end
   global.get $assembly/index/finished
   if
-   local.get $3
+   local.get $2
    call $~lib/rt/pure/__release
    i32.const 632
    i32.const 744
-   i32.const 145
+   i32.const 146
    i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $3
-  i32.load
-  local.tee $0
-  i32.const 828
-  i32.gt_u
-  if
-   local.get $0
-   i32.const 16
-   i32.sub
-   local.tee $2
-   local.get $2
-   i32.load offset=4
-   i32.const 1
-   i32.add
-   i32.store offset=4
-  end
-  local.get $0
-  local.tee $2
-  i32.const 828
-  i32.gt_u
-  if
-   local.get $2
-   i32.const 16
-   i32.sub
-   local.tee $4
-   local.get $4
-   i32.load offset=4
-   i32.const 1
-   i32.add
-   i32.store offset=4
-  end
   local.get $2
-  local.set $4
-  local.get $3
   i32.load offset=4
-  local.set $7
+  local.set $4
   global.get $assembly/index/temp
-  local.set $8
-  global.get $assembly/index/buffer
   local.set $6
+  global.get $assembly/index/buffer
+  local.set $5
   global.get $assembly/index/bytesHashed
   local.get $1
   i32.add
@@ -2978,20 +2952,20 @@
     select
     if
      global.get $assembly/index/bufferLength
-     local.tee $9
+     local.tee $7
      i32.const 1
      i32.add
      global.set $assembly/index/bufferLength
-     local.get $5
-     local.tee $2
+     local.get $3
+     local.tee $0
      i32.const 1
      i32.add
-     local.set $5
-     local.get $6
-     local.get $9
-     i32.add
-     local.get $2
+     local.set $3
+     local.get $5
      local.get $7
+     i32.add
+     local.get $0
+     local.get $4
      i32.add
      i32.load8_u
      i32.store8
@@ -3006,8 +2980,8 @@
    i32.const 64
    i32.eq
    if
-    local.get $8
     local.get $6
+    local.get $5
     i32.const 0
     i32.const 64
     call $assembly/index/hashBlocks
@@ -3020,20 +2994,20 @@
   i32.const 64
   i32.ge_s
   if
-   local.get $8
+   local.get $6
    local.get $4
-   local.get $5
+   local.get $3
    local.get $1
    call $assembly/index/hashBlocks
-   local.set $5
+   local.set $3
    local.get $1
    i32.const 63
    i32.and
    local.set $1
   end
-  local.get $6
   local.get $5
-  local.get $7
+  local.get $3
+  local.get $4
   i32.add
   local.get $1
   call $~lib/memory/memory.copy
@@ -3041,11 +3015,7 @@
   local.get $1
   i32.add
   global.set $assembly/index/bufferLength
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $4
-  call $~lib/rt/pure/__release
-  local.get $3
+  local.get $2
   call $~lib/rt/pure/__release
  )
  (func $assembly/index/finish (; 31 ;) (type $FUNCSIG$vi) (param $0 i32)
@@ -3402,12 +3372,12 @@
   local.get $1
  )
  (func $start (; 34 ;) (type $FUNCSIG$v)
-  i32.const 256
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  global.set $assembly/index/temp
   i32.const 128
   call $~lib/arraybuffer/ArrayBuffer#constructor
   global.set $assembly/index/buffer
+  i32.const 256
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  global.set $assembly/index/temp
   i32.const 32
   call $~lib/arraybuffer/ArrayBuffer#constructor
   global.set $assembly/index/out

--- a/build/untouched.wat
+++ b/build/untouched.wat
@@ -3603,21 +3603,9 @@
   (local $21 i32)
   (local $22 i32)
   (local $23 i32)
-  (local $24 i32)
-  (local $25 i32)
-  local.get $0
-  call $~lib/rt/pure/__retain
-  drop
-  local.get $1
-  call $~lib/rt/pure/__retain
-  drop
   global.get $assembly/index/K
   i32.load offset=4
   local.set $17
-  local.get $1
-  local.set $18
-  local.get $0
-  local.set $19
   block $break|0
    loop $continue|0
     local.get $3
@@ -3656,32 +3644,32 @@
       i32.mul
       i32.add
       local.set $14
-      local.get $19
-      local.set $23
-      local.get $13
-      local.set $22
-      local.get $18
+      local.get $0
       local.set $21
+      local.get $13
+      local.set $20
+      local.get $1
+      local.set $19
       local.get $14
       i32.const 0
       i32.add
-      local.set $20
-      local.get $21
-      local.get $20
+      local.set $18
+      local.get $19
+      local.get $18
       i32.add
       i32.load8_u
       i32.const 255
       i32.and
       i32.const 24
       i32.shl
-      local.get $18
-      local.set $21
+      local.get $1
+      local.set $19
       local.get $14
       i32.const 1
       i32.add
-      local.set $20
-      local.get $21
-      local.get $20
+      local.set $18
+      local.get $19
+      local.get $18
       i32.add
       i32.load8_u
       i32.const 255
@@ -3689,14 +3677,14 @@
       i32.const 16
       i32.shl
       i32.or
-      local.get $18
-      local.set $21
+      local.get $1
+      local.set $19
       local.get $14
       i32.const 2
       i32.add
-      local.set $20
-      local.get $21
-      local.get $20
+      local.set $18
+      local.get $19
+      local.get $18
       i32.add
       i32.load8_u
       i32.const 255
@@ -3704,14 +3692,14 @@
       i32.const 8
       i32.shl
       i32.or
-      local.get $18
-      local.set $21
+      local.get $1
+      local.set $19
       local.get $14
       i32.const 3
       i32.add
-      local.set $20
-      local.get $21
-      local.get $20
+      local.set $18
+      local.get $19
+      local.get $18
       i32.add
       i32.load8_u
       i32.const 255
@@ -3719,13 +3707,13 @@
       i32.const 0
       i32.shl
       i32.or
-      local.set $20
-      local.get $23
-      local.get $22
+      local.set $18
+      local.get $21
+      local.get $20
       i32.const 2
       i32.shl
       i32.add
-      local.get $20
+      local.get $18
       i32.store
       local.get $13
       i32.const 1
@@ -3744,14 +3732,14 @@
       i32.lt_u
       i32.eqz
       br_if $break|2
-      local.get $19
-      local.set $20
+      local.get $0
+      local.set $18
       local.get $13
       i32.const 2
       i32.sub
-      local.set $21
-      local.get $20
-      local.get $21
+      local.set $19
+      local.get $18
+      local.get $19
       i32.const 2
       i32.shl
       i32.add
@@ -3769,14 +3757,14 @@
       i32.shr_u
       i32.xor
       local.set $15
-      local.get $19
-      local.set $23
+      local.get $0
+      local.set $21
       local.get $13
       i32.const 15
       i32.sub
-      local.set $22
-      local.get $23
-      local.get $22
+      local.set $20
+      local.get $21
+      local.get $20
       i32.const 2
       i32.shl
       i32.add
@@ -3794,19 +3782,19 @@
       i32.shr_u
       i32.xor
       local.set $16
-      local.get $19
-      local.set $25
+      local.get $0
+      local.set $23
       local.get $13
-      local.set $24
+      local.set $22
       local.get $15
-      local.get $19
-      local.set $20
+      local.get $0
+      local.set $18
       local.get $13
       i32.const 7
       i32.sub
-      local.set $21
-      local.get $20
-      local.get $21
+      local.set $19
+      local.get $18
+      local.get $19
       i32.const 2
       i32.shl
       i32.add
@@ -3814,26 +3802,26 @@
       i32.add
       local.get $16
       i32.add
-      local.get $19
-      local.set $23
+      local.get $0
+      local.set $21
       local.get $13
       i32.const 16
       i32.sub
-      local.set $22
-      local.get $23
-      local.get $22
+      local.set $20
+      local.get $21
+      local.get $20
       i32.const 2
       i32.shl
       i32.add
       i32.load
       i32.add
-      local.set $21
-      local.get $25
-      local.get $24
+      local.set $19
+      local.get $23
+      local.get $22
       i32.const 2
       i32.shl
       i32.add
-      local.get $21
+      local.get $19
       i32.store
       local.get $13
       i32.const 1
@@ -3876,22 +3864,22 @@
       local.get $11
       i32.add
       local.get $17
-      local.set $22
-      local.get $13
       local.set $20
-      local.get $22
+      local.get $13
+      local.set $18
       local.get $20
+      local.get $18
       i32.const 2
       i32.shl
       i32.add
       i32.load
       i32.add
-      local.get $19
-      local.set $21
+      local.get $0
+      local.set $19
       local.get $13
-      local.set $23
+      local.set $21
+      local.get $19
       local.get $21
-      local.get $23
       i32.const 2
       i32.shl
       i32.add
@@ -3995,12 +3983,6 @@
    unreachable
   end
   local.get $2
-  local.set $21
-  local.get $0
-  call $~lib/rt/pure/__release
-  local.get $1
-  call $~lib/rt/pure/__release
-  local.get $21
  )
  (func $assembly/index/update (; 35 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
@@ -4012,6 +3994,8 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -4021,7 +4005,7 @@
    call $~lib/rt/pure/__release
    i32.const 680
    i32.const 792
-   i32.const 145
+   i32.const 143
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -4034,10 +4018,14 @@
   local.get $0
   i32.load offset=4
   local.set $4
-  global.get $assembly/index/buffer
+  global.get $assembly/index/temp
   local.set $5
-  i32.const 0
+  global.get $assembly/index/buffer
   local.set $6
+  local.get $3
+  local.set $7
+  i32.const 0
+  local.set $8
   global.get $assembly/index/bytesHashed
   local.get $1
   i32.add
@@ -4060,33 +4048,33 @@
      end
      i32.eqz
      br_if $break|0
-     local.get $5
-     local.set $10
+     local.get $6
+     local.set $12
      global.get $assembly/index/bufferLength
-     local.tee $7
+     local.tee $9
      i32.const 1
      i32.add
      global.set $assembly/index/bufferLength
-     local.get $7
-     local.set $9
+     local.get $9
+     local.set $11
      local.get $4
-     local.set $8
-     local.get $6
-     local.tee $7
+     local.set $10
+     local.get $8
+     local.tee $9
      i32.const 1
      i32.add
-     local.set $6
-     local.get $7
-     local.set $7
-     local.get $8
-     local.get $7
-     i32.add
-     i32.load8_u
-     local.set $7
+     local.set $8
+     local.get $9
+     local.set $9
      local.get $10
      local.get $9
      i32.add
-     local.get $7
+     i32.load8_u
+     local.set $9
+     local.get $12
+     local.get $11
+     i32.add
+     local.get $9
      i32.store8
      local.get $1
      i32.const 1
@@ -4100,8 +4088,8 @@
    i32.const 64
    i32.eq
    if
-    global.get $assembly/index/temp
-    global.get $assembly/index/buffer
+    local.get $5
+    local.get $6
     i32.const 0
     i32.const 64
     call $assembly/index/hashBlocks
@@ -4114,27 +4102,27 @@
   i32.const 64
   i32.ge_s
   if
-   global.get $assembly/index/temp
-   local.get $3
-   local.get $6
+   local.get $5
+   local.get $7
+   local.get $8
    local.get $1
    call $assembly/index/hashBlocks
-   local.set $6
+   local.set $8
    local.get $1
    i32.const 63
    i32.and
    local.set $1
   end
-  local.get $5
-  local.get $4
   local.get $6
+  local.get $4
+  local.get $8
   i32.add
   local.get $1
   call $~lib/memory/memory.copy
-  local.get $6
+  local.get $8
   local.get $1
   i32.add
-  local.set $6
+  local.set $8
   global.get $assembly/index/bufferLength
   local.get $1
   i32.add
@@ -4183,6 +4171,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -4209,16 +4198,18 @@
    local.set $4
    global.get $assembly/index/buffer
    local.set $5
-   local.get $5
-   local.set $8
-   local.get $1
-   local.set $7
-   i32.const 128
+   global.get $assembly/index/temp
    local.set $6
+   local.get $5
+   local.set $9
+   local.get $1
+   local.set $8
+   i32.const 128
+   local.set $7
+   local.get $9
    local.get $8
-   local.get $7
    i32.add
-   local.get $6
+   local.get $7
    i32.store8
    local.get $5
    local.get $1
@@ -4248,8 +4239,8 @@
    local.get $3
    call $~lib/polyfills/bswap<i32>
    i32.store
-   global.get $assembly/index/temp
-   global.get $assembly/index/buffer
+   local.get $6
+   local.get $5
    i32.const 0
    local.get $4
    call $assembly/index/hashBlocks
@@ -4258,22 +4249,22 @@
    global.set $assembly/index/finished
   end
   local.get $0
-  local.set $5
-  local.get $5
-  local.set $8
+  local.set $6
+  local.get $6
+  local.set $9
   i32.const 0
-  local.set $7
+  local.set $8
   global.get $assembly/index/H0
   call $~lib/polyfills/bswap<u32>
-  local.set $6
+  local.set $7
+  local.get $9
   local.get $8
-  local.get $7
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $7
   i32.store
-  local.get $5
+  local.get $6
   local.set $3
   i32.const 1
   local.set $2
@@ -4287,67 +4278,39 @@
   i32.add
   local.get $1
   i32.store
-  local.get $5
+  local.get $6
   local.set $7
   i32.const 2
-  local.set $6
+  local.set $5
   global.get $assembly/index/H2
   call $~lib/polyfills/bswap<u32>
   local.set $4
   local.get $7
-  local.get $6
+  local.get $5
   i32.const 2
   i32.shl
   i32.add
   local.get $4
   i32.store
-  local.get $5
-  local.set $2
-  i32.const 3
+  local.get $6
   local.set $1
+  i32.const 3
+  local.set $9
   global.get $assembly/index/H3
   call $~lib/polyfills/bswap<u32>
   local.set $8
-  local.get $2
   local.get $1
+  local.get $9
   i32.const 2
   i32.shl
   i32.add
   local.get $8
   i32.store
-  local.get $5
-  local.set $6
-  i32.const 4
-  local.set $4
-  global.get $assembly/index/H4
-  call $~lib/polyfills/bswap<u32>
-  local.set $3
   local.get $6
-  local.get $4
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $3
-  i32.store
-  local.get $5
-  local.set $1
-  i32.const 5
-  local.set $8
-  global.get $assembly/index/H5
-  call $~lib/polyfills/bswap<u32>
-  local.set $7
-  local.get $1
-  local.get $8
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $7
-  i32.store
-  local.get $5
   local.set $4
-  i32.const 6
+  i32.const 4
   local.set $3
-  global.get $assembly/index/H6
+  global.get $assembly/index/H4
   call $~lib/polyfills/bswap<u32>
   local.set $2
   local.get $4
@@ -4357,19 +4320,47 @@
   i32.add
   local.get $2
   i32.store
-  local.get $5
+  local.get $6
   local.set $8
-  i32.const 7
+  i32.const 5
   local.set $7
-  global.get $assembly/index/H7
+  global.get $assembly/index/H5
   call $~lib/polyfills/bswap<u32>
-  local.set $6
+  local.set $5
   local.get $8
   local.get $7
   i32.const 2
   i32.shl
   i32.add
+  local.get $5
+  i32.store
   local.get $6
+  local.set $2
+  i32.const 6
+  local.set $1
+  global.get $assembly/index/H6
+  call $~lib/polyfills/bswap<u32>
+  local.set $9
+  local.get $2
+  local.get $1
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $9
+  i32.store
+  local.get $6
+  local.set $5
+  i32.const 7
+  local.set $4
+  global.get $assembly/index/H7
+  call $~lib/polyfills/bswap<u32>
+  local.set $3
+  local.get $5
+  local.get $4
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $3
   i32.store
   local.get $0
   call $~lib/rt/pure/__release

--- a/build/untouched.wat
+++ b/build/untouched.wat
@@ -1,29 +1,37 @@
 (module
  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
- (type $FUNCSIG$ii (func (param i32) (result i32)))
- (type $FUNCSIG$vi (func (param i32)))
  (type $FUNCSIG$v (func))
- (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
- (type $FUNCSIG$viii (func (param i32 i32 i32)))
- (type $FUNCSIG$vii (func (param i32 i32)))
- (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+ (type $FUNCSIG$viiii (func (param i32 i32 i32 i32)))
+ (type $FUNCSIG$vii (func (param i32 i32)))
+ (type $FUNCSIG$ii (func (param i32) (result i32)))
+ (type $FUNCSIG$viii (func (param i32 i32 i32)))
+ (type $FUNCSIG$vi (func (param i32)))
+ (type $FUNCSIG$iiiii (func (param i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (memory $0 1)
- (data (i32.const 8) "\00\01\00\00\01\00\00\00\00\00\00\00\00\01\00\00\98/\8aB\91D7q\cf\fb\c0\b5\a5\db\b5\e9[\c2V9\f1\11\f1Y\a4\82?\92\d5^\1c\ab\98\aa\07\d8\01[\83\12\be\851$\c3}\0cUt]\ber\fe\b1\de\80\a7\06\dc\9bt\f1\9b\c1\c1i\9b\e4\86G\be\ef\c6\9d\c1\0f\cc\a1\0c$o,\e9-\aa\84tJ\dc\a9\b0\\\da\88\f9vRQ>\98m\c61\a8\c8\'\03\b0\c7\7fY\bf\f3\0b\e0\c6G\91\a7\d5Qc\ca\06g))\14\85\n\b7\'8!\1b.\fcm,M\13\0d8STs\ne\bb\njv.\c9\c2\81\85,r\92\a1\e8\bf\a2Kf\1a\a8p\8bK\c2\a3Ql\c7\19\e8\92\d1$\06\99\d6\855\0e\f4p\a0j\10\16\c1\a4\19\08l7\1eLwH\'\b5\bc\b04\b3\0c\1c9J\aa\d8NO\ca\9c[\f3o.h\ee\82\8ftoc\a5x\14x\c8\84\08\02\c7\8c\fa\ff\be\90\eblP\a4\f7\a3\f9\be\f2xq\c6")
- (data (i32.const 280) "\10\00\00\00\01\00\00\00\04\00\00\00\10\00\00\00\18\00\00\00\18\00\00\00\00\01\00\00@\00\00\00")
- (data (i32.const 312) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
- (data (i32.const 360) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
- (data (i32.const 416) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00S\00H\00A\002\005\006\00:\00 \00c\00a\00n\00\'\00t\00 \00u\00p\00d\00a\00t\00e\00 \00b\00e\00c\00a\00u\00s\00e\00 \00h\00a\00s\00h\00 \00w\00a\00s\00 \00f\00i\00n\00i\00s\00h\00e\00d\00.\00")
- (data (i32.const 528) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00a\00s\00s\00e\00m\00b\00l\00y\00/\00i\00n\00d\00e\00x\00.\00t\00s\00")
- (data (i32.const 584) "\05\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\001\00\00\00\02\00\00\00\93\00\00\00\02\00\00\00")
+ (data (i32.const 8) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00")
+ (data (i32.const 56) "(\00\00\00\01\00\00\00\01\00\00\00(\00\00\00a\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00")
+ (data (i32.const 112) "\1e\00\00\00\01\00\00\00\01\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00p\00u\00r\00e\00.\00t\00s\00")
+ (data (i32.const 160) "$\00\00\00\01\00\00\00\01\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00")
+ (data (i32.const 216) "\14\00\00\00\01\00\00\00\01\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00")
+ (data (i32.const 256) "\00\01\00\00\01\00\00\00\00\00\00\00\00\01\00\00\98/\8aB\91D7q\cf\fb\c0\b5\a5\db\b5\e9[\c2V9\f1\11\f1Y\a4\82?\92\d5^\1c\ab\98\aa\07\d8\01[\83\12\be\851$\c3}\0cUt]\ber\fe\b1\de\80\a7\06\dc\9bt\f1\9b\c1\c1i\9b\e4\86G\be\ef\c6\9d\c1\0f\cc\a1\0c$o,\e9-\aa\84tJ\dc\a9\b0\\\da\88\f9vRQ>\98m\c61\a8\c8\'\03\b0\c7\7fY\bf\f3\0b\e0\c6G\91\a7\d5Qc\ca\06g))\14\85\n\b7\'8!\1b.\fcm,M\13\0d8STs\ne\bb\njv.\c9\c2\81\85,r\92\a1\e8\bf\a2Kf\1a\a8p\8bK\c2\a3Ql\c7\19\e8\92\d1$\06\99\d6\855\0e\f4p\a0j\10\16\c1\a4\19\08l7\1eLwH\'\b5\bc\b04\b3\0c\1c9J\aa\d8NO\ca\9c[\f3o.h\ee\82\8ftoc\a5x\14x\c8\84\08\02\c7\8c\fa\ff\be\90\eblP\a4\f7\a3\f9\be\f2xq\c6")
+ (data (i32.const 528) "\10\00\00\00\01\00\00\00\04\00\00\00\10\00\00\00\10\01\00\00\10\01\00\00\00\01\00\00@\00\00\00")
+ (data (i32.const 560) "\1c\00\00\00\01\00\00\00\01\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data (i32.const 608) "&\00\00\00\01\00\00\00\01\00\00\00&\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00b\00u\00f\00f\00e\00r\00.\00t\00s\00")
+ (data (i32.const 664) "^\00\00\00\01\00\00\00\01\00\00\00^\00\00\00S\00H\00A\002\005\006\00:\00 \00c\00a\00n\00\'\00t\00 \00u\00p\00d\00a\00t\00e\00 \00b\00e\00c\00a\00u\00s\00e\00 \00h\00a\00s\00h\00 \00w\00a\00s\00 \00f\00i\00n\00i\00s\00h\00e\00d\00.\00")
+ (data (i32.const 776) "\"\00\00\00\01\00\00\00\01\00\00\00\"\00\00\00a\00s\00s\00e\00m\00b\00l\00y\00/\00i\00n\00d\00e\00x\00.\00t\00s\00")
+ (data (i32.const 832) "\05\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\00\10\00\00\00\00\00\00\001\00\00\00\02\00\00\00\93\00\00\00\02\00\00\00")
  (table $0 1 funcref)
  (elem (i32.const 0) $null)
- (global $~lib/rt/stub/startOffset (mut i32) (i32.const 0))
- (global $~lib/rt/stub/offset (mut i32) (i32.const 0))
+ (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/rt/pure/CUR (mut i32) (i32.const 0))
+ (global $~lib/rt/pure/END (mut i32) (i32.const 0))
+ (global $~lib/rt/pure/ROOTS (mut i32) (i32.const 0))
+ (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $assembly/index/UINT8ARRAY_ID i32 (i32.const 3))
  (global $assembly/index/digestLength i32 (i32.const 32))
- (global $assembly/index/K i32 (i32.const 296))
+ (global $assembly/index/K i32 (i32.const 544))
  (global $assembly/index/H0 (mut i32) (i32.const 0))
  (global $assembly/index/H1 (mut i32) (i32.const 0))
  (global $assembly/index/H2 (mut i32) (i32.const 0))
@@ -32,20 +40,19 @@
  (global $assembly/index/H5 (mut i32) (i32.const 0))
  (global $assembly/index/H6 (mut i32) (i32.const 0))
  (global $assembly/index/H7 (mut i32) (i32.const 0))
- (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $assembly/index/temp (mut i32) (i32.const 0))
  (global $assembly/index/buffer (mut i32) (i32.const 0))
  (global $assembly/index/bufferLength (mut i32) (i32.const 0))
  (global $assembly/index/bytesHashed (mut i32) (i32.const 0))
  (global $assembly/index/finished (mut i32) (i32.const 0))
  (global $assembly/index/out (mut i32) (i32.const 0))
- (global $~lib/rt/__rtti_base i32 (i32.const 584))
- (global $~lib/heap/__heap_base i32 (i32.const 628))
+ (global $~lib/rt/__rtti_base i32 (i32.const 832))
+ (global $~lib/heap/__heap_base i32 (i32.const 876))
  (export "memory" (memory $0))
- (export "__alloc" (func $~lib/rt/stub/__alloc))
- (export "__retain" (func $~lib/rt/stub/__retain))
- (export "__release" (func $~lib/rt/stub/__release))
- (export "__collect" (func $~lib/rt/stub/__collect))
+ (export "__alloc" (func $~lib/rt/tlsf/__alloc))
+ (export "__retain" (func $~lib/rt/pure/__retain))
+ (export "__release" (func $~lib/rt/pure/__release))
+ (export "__collect" (func $~lib/rt/pure/__collect))
  (export "__rtti_base" (global $~lib/rt/__rtti_base))
  (export "UINT8ARRAY_ID" (global $assembly/index/UINT8ARRAY_ID))
  (export "clean" (func $assembly/index/clean))
@@ -53,7 +60,7 @@
  (export "finish" (func $assembly/index/finish))
  (export "hashMe" (func $assembly/index/hashMe))
  (start $start)
- (func $~lib/rt/stub/__alloc (; 1 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/rt/tlsf/removeBlock (; 1 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -61,457 +68,211 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  local.get $0
-  i32.const 1073741808
-  i32.gt_u
-  if
-   unreachable
-  end
-  global.get $~lib/rt/stub/offset
-  i32.const 16
-  i32.add
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  local.get $1
+  i32.load
   local.set $2
   local.get $2
-  local.get $0
-  local.tee $3
   i32.const 1
-  local.tee $4
-  local.get $3
-  local.get $4
-  i32.gt_u
-  select
-  i32.add
-  i32.const 15
-  i32.add
-  i32.const 15
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 277
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 3
   i32.const -1
   i32.xor
   i32.and
-  local.set $5
-  memory.size
-  local.set $6
-  local.get $5
-  local.get $6
+  local.set $3
+  local.get $3
   i32.const 16
-  i32.shl
-  i32.gt_u
+  i32.ge_u
+  if (result i32)
+   local.get $3
+   i32.const 1073741808
+   i32.lt_u
+  else   
+   i32.const 0
+  end
+  i32.eqz
   if
-   local.get $5
-   local.get $2
-   i32.sub
-   i32.const 65535
-   i32.add
-   i32.const 65535
-   i32.const -1
-   i32.xor
-   i32.and
-   i32.const 16
+   i32.const 0
+   i32.const 24
+   i32.const 279
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $4
+   local.get $3
+   i32.const 4
    i32.shr_u
-   local.set $3
-   local.get $6
-   local.tee $4
-   local.get $3
-   local.tee $7
-   local.get $4
-   local.get $7
-   i32.gt_s
-   select
-   local.set $4
-   local.get $4
-   memory.grow
-   i32.const 0
-   i32.lt_s
-   if
-    local.get $3
-    memory.grow
-    i32.const 0
-    i32.lt_s
-    if
-     unreachable
-    end
-   end
-  end
-  local.get $5
-  global.set $~lib/rt/stub/offset
-  local.get $2
-  i32.const 16
-  i32.sub
-  local.set $8
-  local.get $8
-  local.get $1
-  i32.store offset=8
-  local.get $8
-  local.get $0
-  i32.store offset=12
-  local.get $2
- )
- (func $~lib/rt/stub/__retain (; 2 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
- )
- (func $~lib/rt/stub/__release (; 3 ;) (type $FUNCSIG$vi) (param $0 i32)
-  nop
- )
- (func $~lib/rt/stub/__collect (; 4 ;) (type $FUNCSIG$v)
-  nop
- )
- (func $~lib/memory/memory.fill (; 5 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  (local $7 i32)
-  (local $8 i64)
-  block $~lib/util/memory/memset|inlined.0
-   local.get $0
    local.set $5
-   local.get $1
+  else   
+   i32.const 31
+   local.get $3
+   i32.clz
+   i32.sub
    local.set $4
-   local.get $2
-   local.set $3
    local.get $3
-   i32.eqz
-   if
-    br $~lib/util/memory/memset|inlined.0
-   end
-   local.get $5
    local.get $4
-   i32.store8
-   local.get $5
-   local.get $3
-   i32.add
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $5
+   local.get $4
+   i32.const 8
    i32.const 1
    i32.sub
-   local.get $4
-   i32.store8
-   local.get $3
-   i32.const 2
-   i32.le_u
-   if
-    br $~lib/util/memory/memset|inlined.0
-   end
-   local.get $5
-   i32.const 1
-   i32.add
-   local.get $4
-   i32.store8
-   local.get $5
-   i32.const 2
-   i32.add
-   local.get $4
-   i32.store8
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 2
    i32.sub
-   local.get $4
-   i32.store8
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 3
-   i32.sub
-   local.get $4
-   i32.store8
-   local.get $3
-   i32.const 6
-   i32.le_u
-   if
-    br $~lib/util/memory/memset|inlined.0
-   end
-   local.get $5
-   i32.const 3
-   i32.add
-   local.get $4
-   i32.store8
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.get $4
-   i32.store8
-   local.get $3
-   i32.const 8
-   i32.le_u
-   if
-    br $~lib/util/memory/memset|inlined.0
-   end
-   i32.const 0
-   local.get $5
-   i32.sub
-   i32.const 3
-   i32.and
-   local.set $6
-   local.get $5
-   local.get $6
-   i32.add
-   local.set $5
-   local.get $3
-   local.get $6
-   i32.sub
-   local.set $3
-   local.get $3
-   i32.const -4
-   i32.and
-   local.set $3
-   i32.const -1
-   i32.const 255
-   i32.div_u
-   local.get $4
-   i32.const 255
-   i32.and
-   i32.mul
-   local.set $7
-   local.get $5
-   local.get $7
-   i32.store
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 4
-   i32.sub
-   local.get $7
-   i32.store
-   local.get $3
-   i32.const 8
-   i32.le_u
-   if
-    br $~lib/util/memory/memset|inlined.0
-   end
-   local.get $5
-   i32.const 4
-   i32.add
-   local.get $7
-   i32.store
-   local.get $5
-   i32.const 8
-   i32.add
-   local.get $7
-   i32.store
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 12
-   i32.sub
-   local.get $7
-   i32.store
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 8
-   i32.sub
-   local.get $7
-   i32.store
-   local.get $3
-   i32.const 24
-   i32.le_u
-   if
-    br $~lib/util/memory/memset|inlined.0
-   end
-   local.get $5
-   i32.const 12
-   i32.add
-   local.get $7
-   i32.store
-   local.get $5
-   i32.const 16
-   i32.add
-   local.get $7
-   i32.store
-   local.get $5
-   i32.const 20
-   i32.add
-   local.get $7
-   i32.store
-   local.get $5
-   i32.const 24
-   i32.add
-   local.get $7
-   i32.store
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 28
-   i32.sub
-   local.get $7
-   i32.store
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 24
-   i32.sub
-   local.get $7
-   i32.store
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 20
-   i32.sub
-   local.get $7
-   i32.store
-   local.get $5
-   local.get $3
-   i32.add
-   i32.const 16
-   i32.sub
-   local.get $7
-   i32.store
-   i32.const 24
-   local.get $5
-   i32.const 4
-   i32.and
-   i32.add
-   local.set $6
-   local.get $5
-   local.get $6
-   i32.add
-   local.set $5
-   local.get $3
-   local.get $6
-   i32.sub
-   local.set $3
-   local.get $7
-   i64.extend_i32_u
-   local.get $7
-   i64.extend_i32_u
-   i64.const 32
-   i64.shl
-   i64.or
-   local.set $8
-   block $break|0
-    loop $continue|0
-     local.get $3
-     i32.const 32
-     i32.ge_u
-     i32.eqz
-     br_if $break|0
-     local.get $5
-     local.get $8
-     i64.store
-     local.get $5
-     i32.const 8
-     i32.add
-     local.get $8
-     i64.store
-     local.get $5
-     i32.const 16
-     i32.add
-     local.get $8
-     i64.store
-     local.get $5
-     i32.const 24
-     i32.add
-     local.get $8
-     i64.store
-     local.get $3
-     i32.const 32
-     i32.sub
-     local.set $3
-     local.get $5
-     i32.const 32
-     i32.add
-     local.set $5
-     br $continue|0
-    end
-    unreachable
-   end
+   local.set $4
   end
- )
- (func $~lib/arraybuffer/ArrayBuffer#constructor (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  local.get $1
-  i32.const 1073741808
-  i32.gt_u
+  local.get $4
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $5
+   i32.const 16
+   i32.lt_u
+  else   
+   i32.const 0
+  end
+  i32.eqz
   if
-   i32.const 328
-   i32.const 376
-   i32.const 57
-   i32.const 42
+   i32.const 0
+   i32.const 24
+   i32.const 292
+   i32.const 13
    call $~lib/builtins/abort
    unreachable
   end
   local.get $1
-  i32.const 0
-  call $~lib/rt/stub/__alloc
-  local.set $2
-  local.get $2
-  i32.const 0
+  i32.load offset=16
+  local.set $6
   local.get $1
-  call $~lib/memory/memory.fill
-  local.get $2
-  call $~lib/rt/stub/__retain
- )
- (func $start:assembly/index (; 7 ;) (type $FUNCSIG$v)
-  (local $0 i32)
-  (local $1 i32)
-  i32.const 0
-  i32.const 256
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  global.set $assembly/index/temp
-  i32.const 0
-  i32.const 128
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  global.set $assembly/index/buffer
-  i32.const 0
-  global.get $assembly/index/digestLength
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  global.set $assembly/index/out
- )
- (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 8 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  i32.load offset=20
+  local.set $7
+  local.get $6
+  if
+   local.get $6
+   local.get $7
+   i32.store offset=20
+  end
+  local.get $7
+  if
+   local.get $7
+   local.get $6
+   i32.store offset=16
+  end
+  local.get $1
   local.get $0
-  i32.const 16
-  i32.sub
-  i32.load offset=12
+  local.set $10
+  local.get $4
+  local.set $9
+  local.get $5
+  local.set $8
+  local.get $10
+  local.get $9
+  i32.const 4
+  i32.shl
+  local.get $8
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  i32.eq
+  if
+   local.get $0
+   local.set $11
+   local.get $4
+   local.set $10
+   local.get $5
+   local.set $9
+   local.get $7
+   local.set $8
+   local.get $11
+   local.get $10
+   i32.const 4
+   i32.shl
+   local.get $9
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   local.get $8
+   i32.store offset=96
+   local.get $7
+   i32.eqz
+   if
+    local.get $0
+    local.set $9
+    local.get $4
+    local.set $8
+    local.get $9
+    local.get $8
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.set $9
+    local.get $0
+    local.set $8
+    local.get $4
+    local.set $11
+    local.get $9
+    i32.const 1
+    local.get $5
+    i32.shl
+    i32.const -1
+    i32.xor
+    i32.and
+    local.tee $9
+    local.set $10
+    local.get $8
+    local.get $11
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $10
+    i32.store offset=4
+    local.get $9
+    i32.eqz
+    if
+     local.get $0
+     local.get $0
+     i32.load
+     i32.const 1
+     local.get $4
+     i32.shl
+     i32.const -1
+     i32.xor
+     i32.and
+     i32.store
+    end
+   end
+  end
  )
- (func $assembly/index/reset (; 9 ;) (type $FUNCSIG$v)
-  i32.const 1779033703
-  global.set $assembly/index/H0
-  i32.const -1150833019
-  global.set $assembly/index/H1
-  i32.const 1013904242
-  global.set $assembly/index/H2
-  i32.const -1521486534
-  global.set $assembly/index/H3
-  i32.const 1359893119
-  global.set $assembly/index/H4
-  i32.const -1694144372
-  global.set $assembly/index/H5
-  i32.const 528734635
-  global.set $assembly/index/H6
-  i32.const 1541459225
-  global.set $assembly/index/H7
-  i32.const 0
-  global.set $assembly/index/bufferLength
-  i32.const 0
-  global.set $assembly/index/bytesHashed
-  i32.const 0
-  global.set $assembly/index/finished
- )
- (func $assembly/index/clean (; 10 ;) (type $FUNCSIG$v)
-  global.get $assembly/index/buffer
-  i32.const 0
-  global.get $assembly/index/buffer
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  call $~lib/memory/memory.fill
-  global.get $assembly/index/temp
-  i32.const 0
-  global.get $assembly/index/temp
-  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
-  call $~lib/memory/memory.fill
-  call $assembly/index/reset
- )
- (func $~lib/typedarray/Uint8Array#get:buffer (; 11 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.load
-  call $~lib/rt/stub/__retain
- )
- (func $~lib/array/Array<u32>#get:buffer (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.load
-  call $~lib/rt/stub/__retain
- )
- (func $assembly/index/hashBlocks (; 13 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $~lib/rt/tlsf/insertBlock (; 2 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -522,474 +283,1219 @@
   (local $11 i32)
   (local $12 i32)
   (local $13 i32)
-  (local $14 i32)
-  (local $15 i32)
-  (local $16 i32)
-  (local $17 i32)
-  (local $18 i32)
-  (local $19 i32)
-  (local $20 i32)
-  (local $21 i32)
-  (local $22 i32)
-  (local $23 i32)
-  (local $24 i32)
-  (local $25 i32)
-  local.get $0
-  call $~lib/rt/stub/__retain
-  drop
   local.get $1
-  call $~lib/rt/stub/__retain
-  drop
-  global.get $assembly/index/K
-  call $~lib/array/Array<u32>#get:buffer
-  local.tee $17
-  call $~lib/rt/stub/__retain
-  local.set $18
-  block $break|0
-   loop $continue|0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 205
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load
+  local.set $2
+  local.get $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 207
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.set $3
+  local.get $3
+  i32.const 16
+  i32.add
+  local.get $3
+  i32.load
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.add
+  local.set $4
+  local.get $4
+  i32.load
+  local.set $5
+  local.get $5
+  i32.const 1
+  i32.and
+  if
+   local.get $2
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $3
+   local.get $3
+   i32.const 1073741808
+   i32.lt_u
+   if
+    local.get $0
+    local.get $4
+    call $~lib/rt/tlsf/removeBlock
+    local.get $1
+    local.get $2
+    i32.const 3
+    i32.and
     local.get $3
-    i32.const 64
-    i32.ge_u
+    i32.or
+    local.tee $2
+    i32.store
+    local.get $1
+    local.set $6
+    local.get $6
+    i32.const 16
+    i32.add
+    local.get $6
+    i32.load
+    i32.const 3
+    i32.const -1
+    i32.xor
+    i32.and
+    i32.add
+    local.set $4
+    local.get $4
+    i32.load
+    local.set $5
+   end
+  end
+  local.get $2
+  i32.const 2
+  i32.and
+  if
+   local.get $1
+   local.set $6
+   local.get $6
+   i32.const 4
+   i32.sub
+   i32.load
+   local.set $6
+   local.get $6
+   i32.load
+   local.set $3
+   local.get $3
+   i32.const 1
+   i32.and
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 24
+    i32.const 228
+    i32.const 15
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $3
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 16
+   i32.add
+   local.get $2
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.set $7
+   local.get $7
+   i32.const 1073741808
+   i32.lt_u
+   if
+    local.get $0
+    local.get $6
+    call $~lib/rt/tlsf/removeBlock
+    local.get $6
+    local.get $3
+    i32.const 3
+    i32.and
+    local.get $7
+    i32.or
+    local.tee $2
+    i32.store
+    local.get $6
+    local.set $1
+   end
+  end
+  local.get $4
+  local.get $5
+  i32.const 2
+  i32.or
+  i32.store
+  local.get $2
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $8
+  local.get $8
+  i32.const 16
+  i32.ge_u
+  if (result i32)
+   local.get $8
+   i32.const 1073741808
+   i32.lt_u
+  else   
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 243
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 16
+  i32.add
+  local.get $8
+  i32.add
+  local.get $4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 244
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  i32.const 4
+  i32.sub
+  local.get $1
+  i32.store
+  local.get $8
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $9
+   local.get $8
+   i32.const 4
+   i32.shr_u
+   local.set $10
+  else   
+   i32.const 31
+   local.get $8
+   i32.clz
+   i32.sub
+   local.set $9
+   local.get $8
+   local.get $9
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $10
+   local.get $9
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $9
+  end
+  local.get $9
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $10
+   i32.const 16
+   i32.lt_u
+  else   
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 260
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.set $7
+  local.get $9
+  local.set $3
+  local.get $10
+  local.set $6
+  local.get $7
+  local.get $3
+  i32.const 4
+  i32.shl
+  local.get $6
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  local.set $11
+  local.get $1
+  i32.const 0
+  i32.store offset=16
+  local.get $1
+  local.get $11
+  i32.store offset=20
+  local.get $11
+  if
+   local.get $11
+   local.get $1
+   i32.store offset=16
+  end
+  local.get $0
+  local.set $12
+  local.get $9
+  local.set $7
+  local.get $10
+  local.set $3
+  local.get $1
+  local.set $6
+  local.get $12
+  local.get $7
+  i32.const 4
+  i32.shl
+  local.get $3
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $6
+  i32.store offset=96
+  local.get $0
+  local.get $0
+  i32.load
+  i32.const 1
+  local.get $9
+  i32.shl
+  i32.or
+  i32.store
+  local.get $0
+  local.set $13
+  local.get $9
+  local.set $12
+  local.get $0
+  local.set $3
+  local.get $9
+  local.set $6
+  local.get $3
+  local.get $6
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const 1
+  local.get $10
+  i32.shl
+  i32.or
+  local.set $7
+  local.get $13
+  local.get $12
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $7
+  i32.store offset=4
+ )
+ (func $~lib/rt/tlsf/addMemory (; 3 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $1
+  local.get $2
+  i32.le_u
+  if (result i32)
+   local.get $1
+   i32.const 15
+   i32.and
+   i32.eqz
+  else   
+   i32.const 0
+  end
+  if (result i32)
+   local.get $2
+   i32.const 15
+   i32.and
+   i32.eqz
+  else   
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 386
+   i32.const 4
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  local.set $4
+  i32.const 0
+  local.set $5
+  local.get $4
+  if
+   local.get $1
+   local.get $4
+   i32.const 16
+   i32.add
+   i32.ge_u
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 24
+    i32.const 396
+    i32.const 15
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 16
+   i32.sub
+   local.get $4
+   i32.eq
+   if
+    local.get $1
+    i32.const 16
+    i32.sub
+    local.set $1
+    local.get $4
+    i32.load
+    local.set $5
+   else    
+    nop
+   end
+  else   
+   local.get $1
+   local.get $0
+   i32.const 1572
+   i32.add
+   i32.ge_u
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 24
+    i32.const 408
+    i32.const 4
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $2
+  local.get $1
+  i32.sub
+  local.set $6
+  local.get $6
+  i32.const 48
+  i32.lt_u
+  if
+   i32.const 0
+   return
+  end
+  local.get $6
+  i32.const 16
+  i32.const 1
+  i32.shl
+  i32.sub
+  local.set $7
+  local.get $1
+  local.set $8
+  local.get $8
+  local.get $7
+  i32.const 1
+  i32.or
+  local.get $5
+  i32.const 2
+  i32.and
+  i32.or
+  i32.store
+  local.get $8
+  i32.const 0
+  i32.store offset=16
+  local.get $8
+  i32.const 0
+  i32.store offset=20
+  local.get $1
+  local.get $6
+  i32.add
+  i32.const 16
+  i32.sub
+  local.set $4
+  local.get $4
+  i32.const 0
+  i32.const 2
+  i32.or
+  i32.store
+  local.get $0
+  local.set $9
+  local.get $4
+  local.set $3
+  local.get $9
+  local.get $3
+  i32.store offset=1568
+  local.get $0
+  local.get $8
+  call $~lib/rt/tlsf/insertBlock
+  i32.const 1
+ )
+ (func $~lib/rt/tlsf/initializeRoot (; 4 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  global.get $~lib/heap/__heap_base
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.set $0
+  memory.size
+  local.set $1
+  local.get $0
+  i32.const 1572
+  i32.add
+  i32.const 65535
+  i32.add
+  i32.const 65535
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.shr_u
+  local.set $2
+  local.get $2
+  local.get $1
+  i32.gt_s
+  if (result i32)
+   local.get $2
+   local.get $1
+   i32.sub
+   memory.grow
+   i32.const 0
+   i32.lt_s
+  else   
+   i32.const 0
+  end
+  if
+   unreachable
+  end
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.const 0
+  i32.store
+  local.get $3
+  local.set $5
+  i32.const 0
+  local.set $4
+  local.get $5
+  local.get $4
+  i32.store offset=1568
+  block $break|0
+   i32.const 0
+   local.set $5
+   loop $loop|0
+    local.get $5
+    i32.const 23
+    i32.lt_u
     i32.eqz
     br_if $break|0
-    global.get $assembly/index/H0
-    local.set $4
-    global.get $assembly/index/H1
-    local.set $5
-    global.get $assembly/index/H2
-    local.set $6
-    global.get $assembly/index/H3
+    local.get $3
     local.set $7
-    global.get $assembly/index/H4
-    local.set $8
-    global.get $assembly/index/H5
-    local.set $9
-    global.get $assembly/index/H6
-    local.set $10
-    global.get $assembly/index/H7
-    local.set $11
+    local.get $5
+    local.set $6
+    i32.const 0
+    local.set $4
+    local.get $7
+    local.get $6
+    i32.const 2
+    i32.shl
+    i32.add
+    local.get $4
+    i32.store offset=4
     block $break|1
      i32.const 0
-     local.set $13
+     local.set $7
      loop $loop|1
-      local.get $13
+      local.get $7
       i32.const 16
       i32.lt_u
       i32.eqz
       br_if $break|1
-      local.get $2
-      local.get $13
+      local.get $3
+      local.set $9
+      local.get $5
+      local.set $8
+      local.get $7
+      local.set $6
+      i32.const 0
+      local.set $4
+      local.get $9
+      local.get $8
       i32.const 4
-      i32.mul
-      i32.add
-      local.set $14
-      local.get $0
-      call $~lib/rt/stub/__retain
-      local.set $23
-      local.get $13
-      local.set $22
-      local.get $1
-      call $~lib/rt/stub/__retain
-      local.set $20
-      local.get $14
-      i32.const 0
-      i32.add
-      local.set $19
-      local.get $20
-      local.get $19
-      i32.add
-      i32.load8_u
-      local.set $21
-      local.get $20
-      call $~lib/rt/stub/__release
-      local.get $21
-      i32.const 255
-      i32.and
-      i32.const 24
       i32.shl
-      local.get $1
-      call $~lib/rt/stub/__retain
-      local.set $19
-      local.get $14
-      i32.const 1
+      local.get $6
       i32.add
-      local.set $21
-      local.get $19
-      local.get $21
-      i32.add
-      i32.load8_u
-      local.set $20
-      local.get $19
-      call $~lib/rt/stub/__release
-      local.get $20
-      i32.const 255
-      i32.and
-      i32.const 16
-      i32.shl
-      i32.or
-      local.get $1
-      call $~lib/rt/stub/__retain
-      local.set $21
-      local.get $14
-      i32.const 2
-      i32.add
-      local.set $20
-      local.get $21
-      local.get $20
-      i32.add
-      i32.load8_u
-      local.set $19
-      local.get $21
-      call $~lib/rt/stub/__release
-      local.get $19
-      i32.const 255
-      i32.and
-      i32.const 8
-      i32.shl
-      i32.or
-      local.get $1
-      call $~lib/rt/stub/__retain
-      local.set $20
-      local.get $14
-      i32.const 3
-      i32.add
-      local.set $19
-      local.get $20
-      local.get $19
-      i32.add
-      i32.load8_u
-      local.set $21
-      local.get $20
-      call $~lib/rt/stub/__release
-      local.get $21
-      i32.const 255
-      i32.and
-      i32.const 0
-      i32.shl
-      i32.or
-      local.set $21
-      local.get $23
-      local.get $22
       i32.const 2
       i32.shl
       i32.add
-      local.get $21
-      i32.store
-      local.get $23
-      call $~lib/rt/stub/__release
-      local.get $13
+      local.get $4
+      i32.store offset=96
+      local.get $7
       i32.const 1
       i32.add
-      local.set $13
+      local.set $7
       br $loop|1
      end
      unreachable
     end
-    block $break|2
-     i32.const 16
-     local.set $13
-     loop $loop|2
-      local.get $13
-      i32.const 64
-      i32.lt_u
-      i32.eqz
-      br_if $break|2
-      local.get $0
-      call $~lib/rt/stub/__retain
-      local.set $20
-      local.get $13
-      i32.const 2
-      i32.sub
-      local.set $19
-      local.get $20
-      local.get $19
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.set $23
-      local.get $20
-      call $~lib/rt/stub/__release
-      local.get $23
-      local.set $12
-      local.get $12
-      i32.const 17
-      i32.rotr
-      local.get $12
-      i32.const 19
-      i32.rotr
-      i32.xor
-      local.get $12
-      i32.const 10
-      i32.shr_u
-      i32.xor
-      local.set $15
-      local.get $0
-      call $~lib/rt/stub/__retain
-      local.set $22
-      local.get $13
-      i32.const 15
-      i32.sub
-      local.set $21
-      local.get $22
-      local.get $21
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.set $20
-      local.get $22
-      call $~lib/rt/stub/__release
-      local.get $20
-      local.set $12
-      local.get $12
-      i32.const 7
-      i32.rotr
-      local.get $12
-      i32.const 18
-      i32.rotr
-      i32.xor
-      local.get $12
-      i32.const 3
-      i32.shr_u
-      i32.xor
-      local.set $16
-      local.get $0
-      call $~lib/rt/stub/__retain
-      local.set $25
-      local.get $13
-      local.set $24
-      local.get $15
-      local.get $0
-      call $~lib/rt/stub/__retain
-      local.set $19
-      local.get $13
-      i32.const 7
-      i32.sub
-      local.set $23
-      local.get $19
-      local.get $23
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.set $22
-      local.get $19
-      call $~lib/rt/stub/__release
-      local.get $22
-      i32.add
-      local.get $16
-      i32.add
-      local.get $0
-      call $~lib/rt/stub/__retain
-      local.set $21
-      local.get $13
-      i32.const 16
-      i32.sub
-      local.set $20
-      local.get $21
-      local.get $20
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.set $19
-      local.get $21
-      call $~lib/rt/stub/__release
-      local.get $19
-      i32.add
-      local.set $22
-      local.get $25
-      local.get $24
-      i32.const 2
-      i32.shl
-      i32.add
-      local.get $22
-      i32.store
-      local.get $25
-      call $~lib/rt/stub/__release
-      local.get $13
-      i32.const 1
-      i32.add
-      local.set $13
-      br $loop|2
-     end
-     unreachable
-    end
-    block $break|3
-     i32.const 0
-     local.set $13
-     loop $loop|3
-      local.get $13
-      i32.const 64
-      i32.lt_u
-      i32.eqz
-      br_if $break|3
-      local.get $8
-      i32.const 6
-      i32.rotr
-      local.get $8
-      i32.const 11
-      i32.rotr
-      i32.xor
-      local.get $8
-      i32.const 25
-      i32.rotr
-      i32.xor
-      local.get $8
-      local.get $9
-      i32.and
-      local.get $8
-      i32.const -1
-      i32.xor
-      local.get $10
-      i32.and
-      i32.xor
-      i32.add
-      local.get $11
-      i32.add
-      local.get $18
-      call $~lib/rt/stub/__retain
-      local.set $19
-      local.get $13
-      local.set $23
-      local.get $19
-      local.get $23
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.set $25
-      local.get $19
-      call $~lib/rt/stub/__release
-      local.get $25
-      i32.add
-      local.get $0
-      call $~lib/rt/stub/__retain
-      local.set $21
-      local.get $13
-      local.set $20
-      local.get $21
-      local.get $20
-      i32.const 2
-      i32.shl
-      i32.add
-      i32.load
-      local.set $19
-      local.get $21
-      call $~lib/rt/stub/__release
-      local.get $19
-      i32.add
-      local.set $15
-      local.get $4
-      i32.const 2
-      i32.rotr
-      local.get $4
-      i32.const 13
-      i32.rotr
-      i32.xor
-      local.get $4
-      i32.const 22
-      i32.rotr
-      i32.xor
-      local.get $4
-      local.get $5
-      i32.and
-      local.get $4
-      local.get $6
-      i32.and
-      i32.xor
-      local.get $5
-      local.get $6
-      i32.and
-      i32.xor
-      i32.add
-      local.set $16
-      local.get $10
-      local.set $11
-      local.get $9
-      local.set $10
-      local.get $8
-      local.set $9
-      local.get $7
-      local.get $15
-      i32.add
-      local.set $8
-      local.get $6
-      local.set $7
-      local.get $5
-      local.set $6
-      local.get $4
-      local.set $5
-      local.get $15
-      local.get $16
-      i32.add
-      local.set $4
-      local.get $13
-      i32.const 1
-      i32.add
-      local.set $13
-      br $loop|3
-     end
-     unreachable
-    end
-    global.get $assembly/index/H0
-    local.get $4
-    i32.add
-    global.set $assembly/index/H0
-    global.get $assembly/index/H1
     local.get $5
+    i32.const 1
     i32.add
-    global.set $assembly/index/H1
-    global.get $assembly/index/H2
-    local.get $6
-    i32.add
-    global.set $assembly/index/H2
-    global.get $assembly/index/H3
-    local.get $7
-    i32.add
-    global.set $assembly/index/H3
-    global.get $assembly/index/H4
-    local.get $8
-    i32.add
-    global.set $assembly/index/H4
-    global.get $assembly/index/H5
-    local.get $9
-    i32.add
-    global.set $assembly/index/H5
-    global.get $assembly/index/H6
-    local.get $10
-    i32.add
-    global.set $assembly/index/H6
-    global.get $assembly/index/H7
-    local.get $11
-    i32.add
-    global.set $assembly/index/H7
-    local.get $2
-    i32.const 64
-    i32.add
-    local.set $2
-    local.get $3
-    i32.const 64
-    i32.sub
-    local.set $3
-    br $continue|0
+    local.set $5
+    br $loop|0
    end
    unreachable
   end
-  local.get $2
-  local.set $21
-  local.get $17
-  call $~lib/rt/stub/__release
-  local.get $18
-  call $~lib/rt/stub/__release
+  local.get $3
   local.get $0
-  call $~lib/rt/stub/__release
-  local.get $1
-  call $~lib/rt/stub/__release
-  local.get $21
+  i32.const 1572
+  i32.add
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  memory.size
+  i32.const 16
+  i32.shl
+  call $~lib/rt/tlsf/addMemory
+  drop
+  local.get $3
+  global.set $~lib/rt/tlsf/ROOT
  )
- (func $~lib/util/memory/memcpy (; 14 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/rt/tlsf/prepareSize (; 5 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.const 1073741808
+  i32.ge_u
+  if
+   i32.const 72
+   i32.const 24
+   i32.const 457
+   i32.const 29
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 15
+  i32.add
+  i32.const 15
+  i32.const -1
+  i32.xor
+  i32.and
+  local.tee $1
+  i32.const 16
+  local.tee $2
+  local.get $1
+  local.get $2
+  i32.gt_u
+  select
+ )
+ (func $~lib/rt/tlsf/searchBlock (; 6 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  local.get $1
+  i32.const 256
+  i32.lt_u
+  if
+   i32.const 0
+   local.set $2
+   local.get $1
+   i32.const 4
+   i32.shr_u
+   local.set $3
+  else   
+   local.get $1
+   i32.const 536870904
+   i32.lt_u
+   if (result i32)
+    local.get $1
+    i32.const 1
+    i32.const 27
+    local.get $1
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+   else    
+    local.get $1
+   end
+   local.set $4
+   i32.const 31
+   local.get $4
+   i32.clz
+   i32.sub
+   local.set $2
+   local.get $4
+   local.get $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 1
+   i32.const 4
+   i32.shl
+   i32.xor
+   local.set $3
+   local.get $2
+   i32.const 8
+   i32.const 1
+   i32.sub
+   i32.sub
+   local.set $2
+  end
+  local.get $2
+  i32.const 23
+  i32.lt_u
+  if (result i32)
+   local.get $3
+   i32.const 16
+   i32.lt_u
+  else   
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 338
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.set $5
+  local.get $2
+  local.set $4
+  local.get $5
+  local.get $4
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const 0
+  i32.const -1
+  i32.xor
+  local.get $3
+  i32.shl
+  i32.and
+  local.set $6
+  i32.const 0
+  local.set $7
+  local.get $6
+  i32.eqz
+  if
+   local.get $0
+   i32.load
+   i32.const 0
+   i32.const -1
+   i32.xor
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.shl
+   i32.and
+   local.set $5
+   local.get $5
+   i32.eqz
+   if
+    i32.const 0
+    local.set $7
+   else    
+    local.get $5
+    i32.ctz
+    local.set $2
+    local.get $0
+    local.set $8
+    local.get $2
+    local.set $4
+    local.get $8
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.set $6
+    local.get $6
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 24
+     i32.const 351
+     i32.const 17
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.set $9
+    local.get $2
+    local.set $8
+    local.get $6
+    i32.ctz
+    local.set $4
+    local.get $9
+    local.get $8
+    i32.const 4
+    i32.shl
+    local.get $4
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=96
+    local.set $7
+   end
+  else   
+   local.get $0
+   local.set $9
+   local.get $2
+   local.set $8
+   local.get $6
+   i32.ctz
+   local.set $4
+   local.get $9
+   local.get $8
+   i32.const 4
+   i32.shl
+   local.get $4
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load offset=96
+   local.set $7
+  end
+  local.get $7
+ )
+ (func $~lib/rt/tlsf/growMemory (; 7 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  local.get $1
+  i32.const 536870904
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.const 1
+   i32.sub
+   i32.add
+   local.set $1
+  end
+  memory.size
+  local.set $2
+  local.get $1
+  i32.const 16
+  local.get $2
+  i32.const 16
+  i32.shl
+  i32.const 16
+  i32.sub
+  local.get $0
+  local.set $3
+  local.get $3
+  i32.load offset=1568
+  i32.ne
+  i32.shl
+  i32.add
+  local.set $1
+  local.get $1
+  i32.const 65535
+  i32.add
+  i32.const 65535
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.shr_u
+  local.set $4
+  local.get $2
+  local.tee $3
+  local.get $4
+  local.tee $5
+  local.get $3
+  local.get $5
+  i32.gt_s
+  select
+  local.set $6
+  local.get $6
+  memory.grow
+  i32.const 0
+  i32.lt_s
+  if
+   local.get $4
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    unreachable
+   end
+  end
+  memory.size
+  local.set $7
+  local.get $0
+  local.get $2
+  i32.const 16
+  i32.shl
+  local.get $7
+  i32.const 16
+  i32.shl
+  call $~lib/rt/tlsf/addMemory
+  drop
+ )
+ (func $~lib/rt/tlsf/prepareBlock (; 8 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.load
+  local.set $3
+  local.get $2
+  i32.const 15
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 365
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  local.get $2
+  i32.sub
+  local.set $4
+  local.get $4
+  i32.const 32
+  i32.ge_u
+  if
+   local.get $1
+   local.get $2
+   local.get $3
+   i32.const 2
+   i32.and
+   i32.or
+   i32.store
+   local.get $1
+   i32.const 16
+   i32.add
+   local.get $2
+   i32.add
+   local.set $5
+   local.get $5
+   local.get $4
+   i32.const 16
+   i32.sub
+   i32.const 1
+   i32.or
+   i32.store
+   local.get $0
+   local.get $5
+   call $~lib/rt/tlsf/insertBlock
+  else   
+   local.get $1
+   local.get $3
+   i32.const 1
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.store
+   local.get $1
+   local.set $5
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   local.get $1
+   local.set $5
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $5
+   i32.load
+   i32.const 3
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.add
+   i32.load
+   i32.const 2
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.store
+  end
+ )
+ (func $~lib/rt/tlsf/allocateBlock (; 9 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $1
+  call $~lib/rt/tlsf/prepareSize
+  local.set $2
+  local.get $0
+  local.get $2
+  call $~lib/rt/tlsf/searchBlock
+  local.set $3
+  local.get $3
+  i32.eqz
+  if
+   local.get $0
+   local.get $2
+   call $~lib/rt/tlsf/growMemory
+   local.get $0
+   local.get $2
+   call $~lib/rt/tlsf/searchBlock
+   local.set $3
+   local.get $3
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 24
+    i32.const 487
+    i32.const 15
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $3
+  i32.load
+  i32.const -4
+  i32.and
+  local.get $2
+  i32.ge_u
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 489
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 0
+  i32.store offset=4
+  local.get $3
+  local.get $1
+  i32.store offset=12
+  local.get $0
+  local.get $3
+  call $~lib/rt/tlsf/removeBlock
+  local.get $0
+  local.get $3
+  local.get $2
+  call $~lib/rt/tlsf/prepareBlock
+  local.get $3
+ )
+ (func $~lib/rt/tlsf/__alloc (; 10 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  global.get $~lib/rt/tlsf/ROOT
+  local.set $2
+  local.get $2
+  i32.eqz
+  if
+   call $~lib/rt/tlsf/initializeRoot
+   global.get $~lib/rt/tlsf/ROOT
+   local.set $2
+  end
+  local.get $2
+  local.get $0
+  call $~lib/rt/tlsf/allocateBlock
+  local.set $3
+  local.get $3
+  local.get $1
+  i32.store offset=8
+  local.get $3
+  i32.const 16
+  i32.add
+ )
+ (func $~lib/rt/pure/increment (; 11 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const -268435456
+  i32.and
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.const -268435456
+  i32.and
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 104
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $1
+  i32.const 1
+  i32.add
+  i32.store offset=4
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 107
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/rt/pure/__retain (; 12 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/increment
+  end
+  local.get $0
+ )
+ (func $~lib/rt/tlsf/freeBlock (; 13 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $1
+  i32.load
+  local.set $2
+  local.get $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 546
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  local.get $2
+  i32.const 1
+  i32.or
+  i32.store
+  local.get $0
+  local.get $1
+  call $~lib/rt/tlsf/insertBlock
+ )
+ (func $~lib/rt/__typeinfo (; 14 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/rt/__rtti_base
+  local.set $1
+  local.get $0
+  local.get $1
+  i32.load
+  i32.gt_u
+  if
+   i32.const 176
+   i32.const 232
+   i32.const 22
+   i32.const 27
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 4
+  i32.add
+  local.get $0
+  i32.const 8
+  i32.mul
+  i32.add
+  i32.load
+ )
+ (func $~lib/util/memory/memcpy (; 15 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2017,7 +2523,7 @@
    i32.store8
   end
  )
- (func $~lib/memory/memory.copy (; 15 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/memory/memory.copy (; 16 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2242,7 +2748,1261 @@
    end
   end
  )
- (func $assembly/index/update (; 16 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/tlsf/__free (; 17 ;) (type $FUNCSIG$vi) (param $0 i32)
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 576
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  i32.const 0
+  i32.ne
+  if (result i32)
+   local.get $0
+   i32.const 15
+   i32.and
+   i32.eqz
+  else   
+   i32.const 0
+  end
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 24
+   i32.const 577
+   i32.const 2
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  local.get $0
+  i32.const 16
+  i32.sub
+  call $~lib/rt/tlsf/freeBlock
+ )
+ (func $~lib/rt/pure/growRoots (; 18 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  global.get $~lib/rt/pure/ROOTS
+  local.set $0
+  global.get $~lib/rt/pure/CUR
+  local.get $0
+  i32.sub
+  local.set $1
+  local.get $1
+  i32.const 2
+  i32.mul
+  local.tee $2
+  i32.const 64
+  i32.const 2
+  i32.shl
+  local.tee $3
+  local.get $2
+  local.get $3
+  i32.gt_u
+  select
+  local.set $4
+  local.get $4
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $5
+  local.get $5
+  local.get $0
+  local.get $1
+  call $~lib/memory/memory.copy
+  local.get $0
+  if
+   local.get $0
+   call $~lib/rt/tlsf/__free
+  end
+  local.get $5
+  global.set $~lib/rt/pure/ROOTS
+  local.get $5
+  local.get $1
+  i32.add
+  global.set $~lib/rt/pure/CUR
+  local.get $5
+  local.get $4
+  i32.add
+  global.set $~lib/rt/pure/END
+ )
+ (func $~lib/rt/pure/appendRoot (; 19 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  global.get $~lib/rt/pure/CUR
+  local.set $1
+  local.get $1
+  global.get $~lib/rt/pure/END
+  i32.ge_u
+  if
+   call $~lib/rt/pure/growRoots
+   global.get $~lib/rt/pure/CUR
+   local.set $1
+  end
+  local.get $1
+  local.get $0
+  i32.store
+  local.get $1
+  i32.const 4
+  i32.add
+  global.set $~lib/rt/pure/CUR
+ )
+ (func $~lib/rt/pure/decrement (; 20 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const 268435455
+  i32.and
+  local.set $2
+  local.get $0
+  i32.load
+  i32.const 1
+  i32.and
+  i32.eqz
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 115
+   i32.const 13
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 1
+  i32.eq
+  if
+   local.get $0
+   i32.const 16
+   i32.add
+   i32.const 1
+   call $~lib/rt/__visit_members
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.eqz
+   if
+    global.get $~lib/rt/tlsf/ROOT
+    local.get $0
+    call $~lib/rt/tlsf/freeBlock
+   else    
+    local.get $0
+    i32.const -2147483648
+    i32.const 0
+    i32.or
+    i32.const 0
+    i32.or
+    i32.store offset=4
+   end
+  else   
+   local.get $2
+   i32.const 0
+   i32.gt_u
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 128
+    i32.const 124
+    i32.const 15
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   i32.load offset=8
+   call $~lib/rt/__typeinfo
+   i32.const 16
+   i32.and
+   i32.eqz
+   if
+    local.get $0
+    i32.const -2147483648
+    i32.const 805306368
+    i32.or
+    local.get $2
+    i32.const 1
+    i32.sub
+    i32.or
+    i32.store offset=4
+    local.get $1
+    i32.const -2147483648
+    i32.and
+    i32.eqz
+    if
+     local.get $0
+     call $~lib/rt/pure/appendRoot
+    end
+   else    
+    local.get $0
+    local.get $1
+    i32.const 268435455
+    i32.const -1
+    i32.xor
+    i32.and
+    local.get $2
+    i32.const 1
+    i32.sub
+    i32.or
+    i32.store offset=4
+   end
+  end
+ )
+ (func $~lib/rt/pure/__release (; 21 ;) (type $FUNCSIG$vi) (param $0 i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.gt_u
+  if
+   local.get $0
+   i32.const 16
+   i32.sub
+   call $~lib/rt/pure/decrement
+  end
+ )
+ (func $~lib/rt/pure/markGray (; 22 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const 1879048192
+  i32.and
+  i32.const 268435456
+  i32.ne
+  if
+   local.get $0
+   local.get $1
+   i32.const 1879048192
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 268435456
+   i32.or
+   i32.store offset=4
+   local.get $0
+   i32.const 16
+   i32.add
+   i32.const 2
+   call $~lib/rt/__visit_members
+  end
+ )
+ (func $~lib/rt/pure/scanBlack (; 23 ;) (type $FUNCSIG$vi) (param $0 i32)
+  local.get $0
+  local.get $0
+  i32.load offset=4
+  i32.const 1879048192
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 0
+  i32.or
+  i32.store offset=4
+  local.get $0
+  i32.const 16
+  i32.add
+  i32.const 4
+  call $~lib/rt/__visit_members
+ )
+ (func $~lib/rt/pure/scan (; 24 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const 1879048192
+  i32.and
+  i32.const 268435456
+  i32.eq
+  if
+   local.get $1
+   i32.const 268435455
+   i32.and
+   i32.const 0
+   i32.gt_u
+   if
+    local.get $0
+    call $~lib/rt/pure/scanBlack
+   else    
+    local.get $0
+    local.get $1
+    i32.const 1879048192
+    i32.const -1
+    i32.xor
+    i32.and
+    i32.const 536870912
+    i32.or
+    i32.store offset=4
+    local.get $0
+    i32.const 16
+    i32.add
+    i32.const 3
+    call $~lib/rt/__visit_members
+   end
+  end
+ )
+ (func $~lib/rt/pure/collectWhite (; 25 ;) (type $FUNCSIG$vi) (param $0 i32)
+  (local $1 i32)
+  local.get $0
+  i32.load offset=4
+  local.set $1
+  local.get $1
+  i32.const 1879048192
+  i32.and
+  i32.const 536870912
+  i32.eq
+  if (result i32)
+   local.get $1
+   i32.const -2147483648
+   i32.and
+   i32.eqz
+  else   
+   i32.const 0
+  end
+  if
+   local.get $0
+   local.get $1
+   i32.const 1879048192
+   i32.const -1
+   i32.xor
+   i32.and
+   i32.const 0
+   i32.or
+   i32.store offset=4
+   local.get $0
+   i32.const 16
+   i32.add
+   i32.const 5
+   call $~lib/rt/__visit_members
+   global.get $~lib/rt/tlsf/ROOT
+   local.get $0
+   call $~lib/rt/tlsf/freeBlock
+  end
+ )
+ (func $~lib/rt/pure/__collect (; 26 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  global.get $~lib/rt/pure/ROOTS
+  local.set $0
+  local.get $0
+  local.set $1
+  block $break|0
+   local.get $1
+   local.set $2
+   global.get $~lib/rt/pure/CUR
+   local.set $3
+   loop $loop|0
+    local.get $2
+    local.get $3
+    i32.lt_u
+    i32.eqz
+    br_if $break|0
+    local.get $2
+    i32.load
+    local.set $4
+    local.get $4
+    i32.load offset=4
+    local.set $5
+    local.get $5
+    i32.const 1879048192
+    i32.and
+    i32.const 805306368
+    i32.eq
+    if (result i32)
+     local.get $5
+     i32.const 268435455
+     i32.and
+     i32.const 0
+     i32.gt_u
+    else     
+     i32.const 0
+    end
+    if
+     local.get $4
+     call $~lib/rt/pure/markGray
+     local.get $1
+     local.get $4
+     i32.store
+     local.get $1
+     i32.const 4
+     i32.add
+     local.set $1
+    else     
+     local.get $5
+     i32.const 1879048192
+     i32.and
+     i32.const 0
+     i32.eq
+     if (result i32)
+      local.get $5
+      i32.const 268435455
+      i32.and
+      i32.eqz
+     else      
+      i32.const 0
+     end
+     if
+      global.get $~lib/rt/tlsf/ROOT
+      local.get $4
+      call $~lib/rt/tlsf/freeBlock
+     else      
+      local.get $4
+      local.get $5
+      i32.const -2147483648
+      i32.const -1
+      i32.xor
+      i32.and
+      i32.store offset=4
+     end
+    end
+    local.get $2
+    i32.const 4
+    i32.add
+    local.set $2
+    br $loop|0
+   end
+   unreachable
+  end
+  local.get $1
+  global.set $~lib/rt/pure/CUR
+  block $break|1
+   local.get $0
+   local.set $5
+   loop $loop|1
+    local.get $5
+    local.get $1
+    i32.lt_u
+    i32.eqz
+    br_if $break|1
+    local.get $5
+    i32.load
+    call $~lib/rt/pure/scan
+    local.get $5
+    i32.const 4
+    i32.add
+    local.set $5
+    br $loop|1
+   end
+   unreachable
+  end
+  block $break|2
+   local.get $0
+   local.set $5
+   loop $loop|2
+    local.get $5
+    local.get $1
+    i32.lt_u
+    i32.eqz
+    br_if $break|2
+    local.get $5
+    i32.load
+    local.set $4
+    local.get $4
+    local.get $4
+    i32.load offset=4
+    i32.const -2147483648
+    i32.const -1
+    i32.xor
+    i32.and
+    i32.store offset=4
+    local.get $4
+    call $~lib/rt/pure/collectWhite
+    local.get $5
+    i32.const 4
+    i32.add
+    local.set $5
+    br $loop|2
+   end
+   unreachable
+  end
+  local.get $0
+  global.set $~lib/rt/pure/CUR
+ )
+ (func $~lib/memory/memory.fill (; 27 ;) (type $FUNCSIG$viii) (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i64)
+  block $~lib/util/memory/memset|inlined.0
+   local.get $0
+   local.set $5
+   local.get $1
+   local.set $4
+   local.get $2
+   local.set $3
+   local.get $3
+   i32.eqz
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   local.get $4
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $3
+   i32.const 2
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   i32.const 1
+   i32.add
+   local.get $4
+   i32.store8
+   local.get $5
+   i32.const 2
+   i32.add
+   local.get $4
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 2
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 3
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $3
+   i32.const 6
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   i32.const 3
+   i32.add
+   local.get $4
+   i32.store8
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
+   local.get $4
+   i32.store8
+   local.get $3
+   i32.const 8
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   i32.const 0
+   local.get $5
+   i32.sub
+   i32.const 3
+   i32.and
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.add
+   local.set $5
+   local.get $3
+   local.get $6
+   i32.sub
+   local.set $3
+   local.get $3
+   i32.const -4
+   i32.and
+   local.set $3
+   i32.const -1
+   i32.const 255
+   i32.div_u
+   local.get $4
+   i32.const 255
+   i32.and
+   i32.mul
+   local.set $7
+   local.get $5
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 4
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $3
+   i32.const 8
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   i32.const 4
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 8
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 12
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 8
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $3
+   i32.const 24
+   i32.le_u
+   if
+    br $~lib/util/memory/memset|inlined.0
+   end
+   local.get $5
+   i32.const 12
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 16
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 20
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   i32.const 24
+   i32.add
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 28
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 24
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 20
+   i32.sub
+   local.get $7
+   i32.store
+   local.get $5
+   local.get $3
+   i32.add
+   i32.const 16
+   i32.sub
+   local.get $7
+   i32.store
+   i32.const 24
+   local.get $5
+   i32.const 4
+   i32.and
+   i32.add
+   local.set $6
+   local.get $5
+   local.get $6
+   i32.add
+   local.set $5
+   local.get $3
+   local.get $6
+   i32.sub
+   local.set $3
+   local.get $7
+   i64.extend_i32_u
+   local.get $7
+   i64.extend_i32_u
+   i64.const 32
+   i64.shl
+   i64.or
+   local.set $8
+   block $break|0
+    loop $continue|0
+     local.get $3
+     i32.const 32
+     i32.ge_u
+     i32.eqz
+     br_if $break|0
+     local.get $5
+     local.get $8
+     i64.store
+     local.get $5
+     i32.const 8
+     i32.add
+     local.get $8
+     i64.store
+     local.get $5
+     i32.const 16
+     i32.add
+     local.get $8
+     i64.store
+     local.get $5
+     i32.const 24
+     i32.add
+     local.get $8
+     i64.store
+     local.get $3
+     i32.const 32
+     i32.sub
+     local.set $3
+     local.get $5
+     i32.const 32
+     i32.add
+     local.set $5
+     br $continue|0
+    end
+    unreachable
+   end
+  end
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#constructor (; 28 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 1073741808
+  i32.gt_u
+  if
+   i32.const 576
+   i32.const 624
+   i32.const 57
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 0
+  call $~lib/rt/tlsf/__alloc
+  local.set $2
+  local.get $2
+  i32.const 0
+  local.get $1
+  call $~lib/memory/memory.fill
+  local.get $2
+  call $~lib/rt/pure/__retain
+ )
+ (func $start:assembly/index (; 29 ;) (type $FUNCSIG$v)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 0
+  i32.const 256
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  global.set $assembly/index/temp
+  i32.const 0
+  i32.const 128
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  global.set $assembly/index/buffer
+  i32.const 0
+  global.get $assembly/index/digestLength
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  global.set $assembly/index/out
+ )
+ (func $~lib/arraybuffer/ArrayBuffer#get:byteLength (; 30 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.const 16
+  i32.sub
+  i32.load offset=12
+ )
+ (func $assembly/index/reset (; 31 ;) (type $FUNCSIG$v)
+  i32.const 1779033703
+  global.set $assembly/index/H0
+  i32.const -1150833019
+  global.set $assembly/index/H1
+  i32.const 1013904242
+  global.set $assembly/index/H2
+  i32.const -1521486534
+  global.set $assembly/index/H3
+  i32.const 1359893119
+  global.set $assembly/index/H4
+  i32.const -1694144372
+  global.set $assembly/index/H5
+  i32.const 528734635
+  global.set $assembly/index/H6
+  i32.const 1541459225
+  global.set $assembly/index/H7
+  i32.const 0
+  global.set $assembly/index/bufferLength
+  i32.const 0
+  global.set $assembly/index/bytesHashed
+  i32.const 0
+  global.set $assembly/index/finished
+ )
+ (func $assembly/index/clean (; 32 ;) (type $FUNCSIG$v)
+  global.get $assembly/index/buffer
+  i32.const 0
+  global.get $assembly/index/buffer
+  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  call $~lib/memory/memory.fill
+  global.get $assembly/index/temp
+  i32.const 0
+  global.get $assembly/index/temp
+  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  call $~lib/memory/memory.fill
+  call $assembly/index/reset
+ )
+ (func $~lib/typedarray/Uint8Array#get:buffer (; 33 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+  local.get $0
+  i32.load
+  call $~lib/rt/pure/__retain
+ )
+ (func $assembly/index/hashBlocks (; 34 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $13 i32)
+  (local $14 i32)
+  (local $15 i32)
+  (local $16 i32)
+  (local $17 i32)
+  (local $18 i32)
+  (local $19 i32)
+  (local $20 i32)
+  (local $21 i32)
+  (local $22 i32)
+  (local $23 i32)
+  (local $24 i32)
+  (local $25 i32)
+  local.get $0
+  call $~lib/rt/pure/__retain
+  drop
+  local.get $1
+  call $~lib/rt/pure/__retain
+  drop
+  global.get $assembly/index/K
+  i32.load offset=4
+  local.set $17
+  local.get $1
+  local.set $18
+  local.get $0
+  local.set $19
+  block $break|0
+   loop $continue|0
+    local.get $3
+    i32.const 64
+    i32.ge_u
+    i32.eqz
+    br_if $break|0
+    global.get $assembly/index/H0
+    local.set $4
+    global.get $assembly/index/H1
+    local.set $5
+    global.get $assembly/index/H2
+    local.set $6
+    global.get $assembly/index/H3
+    local.set $7
+    global.get $assembly/index/H4
+    local.set $8
+    global.get $assembly/index/H5
+    local.set $9
+    global.get $assembly/index/H6
+    local.set $10
+    global.get $assembly/index/H7
+    local.set $11
+    block $break|1
+     i32.const 0
+     local.set $13
+     loop $loop|1
+      local.get $13
+      i32.const 16
+      i32.lt_u
+      i32.eqz
+      br_if $break|1
+      local.get $2
+      local.get $13
+      i32.const 4
+      i32.mul
+      i32.add
+      local.set $14
+      local.get $19
+      local.set $23
+      local.get $13
+      local.set $22
+      local.get $18
+      local.set $21
+      local.get $14
+      i32.const 0
+      i32.add
+      local.set $20
+      local.get $21
+      local.get $20
+      i32.add
+      i32.load8_u
+      i32.const 255
+      i32.and
+      i32.const 24
+      i32.shl
+      local.get $18
+      local.set $21
+      local.get $14
+      i32.const 1
+      i32.add
+      local.set $20
+      local.get $21
+      local.get $20
+      i32.add
+      i32.load8_u
+      i32.const 255
+      i32.and
+      i32.const 16
+      i32.shl
+      i32.or
+      local.get $18
+      local.set $21
+      local.get $14
+      i32.const 2
+      i32.add
+      local.set $20
+      local.get $21
+      local.get $20
+      i32.add
+      i32.load8_u
+      i32.const 255
+      i32.and
+      i32.const 8
+      i32.shl
+      i32.or
+      local.get $18
+      local.set $21
+      local.get $14
+      i32.const 3
+      i32.add
+      local.set $20
+      local.get $21
+      local.get $20
+      i32.add
+      i32.load8_u
+      i32.const 255
+      i32.and
+      i32.const 0
+      i32.shl
+      i32.or
+      local.set $20
+      local.get $23
+      local.get $22
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $20
+      i32.store
+      local.get $13
+      i32.const 1
+      i32.add
+      local.set $13
+      br $loop|1
+     end
+     unreachable
+    end
+    block $break|2
+     i32.const 16
+     local.set $13
+     loop $loop|2
+      local.get $13
+      i32.const 64
+      i32.lt_u
+      i32.eqz
+      br_if $break|2
+      local.get $19
+      local.set $20
+      local.get $13
+      i32.const 2
+      i32.sub
+      local.set $21
+      local.get $20
+      local.get $21
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.set $12
+      local.get $12
+      i32.const 17
+      i32.rotr
+      local.get $12
+      i32.const 19
+      i32.rotr
+      i32.xor
+      local.get $12
+      i32.const 10
+      i32.shr_u
+      i32.xor
+      local.set $15
+      local.get $19
+      local.set $23
+      local.get $13
+      i32.const 15
+      i32.sub
+      local.set $22
+      local.get $23
+      local.get $22
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      local.set $12
+      local.get $12
+      i32.const 7
+      i32.rotr
+      local.get $12
+      i32.const 18
+      i32.rotr
+      i32.xor
+      local.get $12
+      i32.const 3
+      i32.shr_u
+      i32.xor
+      local.set $16
+      local.get $19
+      local.set $25
+      local.get $13
+      local.set $24
+      local.get $15
+      local.get $19
+      local.set $20
+      local.get $13
+      i32.const 7
+      i32.sub
+      local.set $21
+      local.get $20
+      local.get $21
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      i32.add
+      local.get $16
+      i32.add
+      local.get $19
+      local.set $23
+      local.get $13
+      i32.const 16
+      i32.sub
+      local.set $22
+      local.get $23
+      local.get $22
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      i32.add
+      local.set $21
+      local.get $25
+      local.get $24
+      i32.const 2
+      i32.shl
+      i32.add
+      local.get $21
+      i32.store
+      local.get $13
+      i32.const 1
+      i32.add
+      local.set $13
+      br $loop|2
+     end
+     unreachable
+    end
+    block $break|3
+     i32.const 0
+     local.set $13
+     loop $loop|3
+      local.get $13
+      i32.const 64
+      i32.lt_u
+      i32.eqz
+      br_if $break|3
+      local.get $8
+      i32.const 6
+      i32.rotr
+      local.get $8
+      i32.const 11
+      i32.rotr
+      i32.xor
+      local.get $8
+      i32.const 25
+      i32.rotr
+      i32.xor
+      local.get $8
+      local.get $9
+      i32.and
+      local.get $8
+      i32.const -1
+      i32.xor
+      local.get $10
+      i32.and
+      i32.xor
+      i32.add
+      local.get $11
+      i32.add
+      local.get $17
+      local.set $22
+      local.get $13
+      local.set $20
+      local.get $22
+      local.get $20
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      i32.add
+      local.get $19
+      local.set $21
+      local.get $13
+      local.set $23
+      local.get $21
+      local.get $23
+      i32.const 2
+      i32.shl
+      i32.add
+      i32.load
+      i32.add
+      local.set $15
+      local.get $4
+      i32.const 2
+      i32.rotr
+      local.get $4
+      i32.const 13
+      i32.rotr
+      i32.xor
+      local.get $4
+      i32.const 22
+      i32.rotr
+      i32.xor
+      local.get $4
+      local.get $5
+      i32.and
+      local.get $4
+      local.get $6
+      i32.and
+      i32.xor
+      local.get $5
+      local.get $6
+      i32.and
+      i32.xor
+      i32.add
+      local.set $16
+      local.get $10
+      local.set $11
+      local.get $9
+      local.set $10
+      local.get $8
+      local.set $9
+      local.get $7
+      local.get $15
+      i32.add
+      local.set $8
+      local.get $6
+      local.set $7
+      local.get $5
+      local.set $6
+      local.get $4
+      local.set $5
+      local.get $15
+      local.get $16
+      i32.add
+      local.set $4
+      local.get $13
+      i32.const 1
+      i32.add
+      local.set $13
+      br $loop|3
+     end
+     unreachable
+    end
+    global.get $assembly/index/H0
+    local.get $4
+    i32.add
+    global.set $assembly/index/H0
+    global.get $assembly/index/H1
+    local.get $5
+    i32.add
+    global.set $assembly/index/H1
+    global.get $assembly/index/H2
+    local.get $6
+    i32.add
+    global.set $assembly/index/H2
+    global.get $assembly/index/H3
+    local.get $7
+    i32.add
+    global.set $assembly/index/H3
+    global.get $assembly/index/H4
+    local.get $8
+    i32.add
+    global.set $assembly/index/H4
+    global.get $assembly/index/H5
+    local.get $9
+    i32.add
+    global.set $assembly/index/H5
+    global.get $assembly/index/H6
+    local.get $10
+    i32.add
+    global.set $assembly/index/H6
+    global.get $assembly/index/H7
+    local.get $11
+    i32.add
+    global.set $assembly/index/H7
+    local.get $2
+    i32.const 64
+    i32.add
+    local.set $2
+    local.get $3
+    i32.const 64
+    i32.sub
+    local.set $3
+    br $continue|0
+   end
+   unreachable
+  end
+  local.get $2
+  local.set $21
+  local.get $0
+  call $~lib/rt/pure/__release
+  local.get $1
+  call $~lib/rt/pure/__release
+  local.get $21
+ )
+ (func $assembly/index/update (; 35 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -2251,16 +4011,17 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
-  call $~lib/rt/stub/__retain
+  call $~lib/rt/pure/__retain
   drop
   global.get $assembly/index/finished
   if
    local.get $0
-   call $~lib/rt/stub/__release
-   i32.const 432
-   i32.const 544
-   i32.const 143
+   call $~lib/rt/pure/__release
+   i32.const 680
+   i32.const 792
+   i32.const 145
    i32.const 4
    call $~lib/builtins/abort
    unreachable
@@ -2268,10 +4029,15 @@
   local.get $0
   call $~lib/typedarray/Uint8Array#get:buffer
   local.tee $2
-  call $~lib/rt/stub/__retain
+  call $~lib/rt/pure/__retain
   local.set $3
-  i32.const 0
+  local.get $0
+  i32.load offset=4
   local.set $4
+  global.get $assembly/index/buffer
+  local.set $5
+  i32.const 0
+  local.set $6
   global.get $assembly/index/bytesHashed
   local.get $1
   i32.add
@@ -2294,42 +4060,34 @@
      end
      i32.eqz
      br_if $break|0
-     global.get $assembly/index/buffer
-     call $~lib/rt/stub/__retain
-     local.set $9
+     local.get $5
+     local.set $10
      global.get $assembly/index/bufferLength
-     local.tee $5
+     local.tee $7
      i32.const 1
      i32.add
      global.set $assembly/index/bufferLength
-     local.get $5
-     local.set $8
-     local.get $3
-     call $~lib/rt/stub/__retain
-     local.set $6
+     local.get $7
+     local.set $9
      local.get $4
-     local.tee $5
+     local.set $8
+     local.get $6
+     local.tee $7
      i32.const 1
      i32.add
-     local.set $4
-     local.get $5
-     local.set $5
-     local.get $6
-     local.get $5
+     local.set $6
+     local.get $7
+     local.set $7
+     local.get $8
+     local.get $7
      i32.add
      i32.load8_u
      local.set $7
-     local.get $6
-     call $~lib/rt/stub/__release
-     local.get $7
-     local.set $7
+     local.get $10
      local.get $9
-     local.get $8
      i32.add
      local.get $7
      i32.store8
-     local.get $9
-     call $~lib/rt/stub/__release
      local.get $1
      i32.const 1
      i32.sub
@@ -2358,37 +4116,37 @@
   if
    global.get $assembly/index/temp
    local.get $3
-   local.get $4
+   local.get $6
    local.get $1
    call $assembly/index/hashBlocks
-   local.set $4
+   local.set $6
    local.get $1
    i32.const 63
    i32.and
    local.set $1
   end
-  global.get $assembly/index/buffer
-  local.get $3
+  local.get $5
   local.get $4
+  local.get $6
   i32.add
   local.get $1
   call $~lib/memory/memory.copy
-  local.get $4
+  local.get $6
   local.get $1
   i32.add
-  local.set $4
+  local.set $6
   global.get $assembly/index/bufferLength
   local.get $1
   i32.add
   global.set $assembly/index/bufferLength
   local.get $2
-  call $~lib/rt/stub/__release
+  call $~lib/rt/pure/__release
   local.get $3
-  call $~lib/rt/stub/__release
+  call $~lib/rt/pure/__release
   local.get $0
-  call $~lib/rt/stub/__release
+  call $~lib/rt/pure/__release
  )
- (func $~lib/polyfills/bswap<i32> (; 17 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i32> (; 36 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -2402,7 +4160,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<u32> (; 18 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u32> (; 37 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -2416,7 +4174,7 @@
   i32.or
   return
  )
- (func $assembly/index/finish (; 19 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $assembly/index/finish (; 38 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -2426,8 +4184,9 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   local.get $0
-  call $~lib/rt/stub/__retain
+  call $~lib/rt/pure/__retain
   drop
   global.get $assembly/index/finished
   i32.eqz
@@ -2451,98 +4210,88 @@
    i32.shl
    local.set $4
    global.get $assembly/index/buffer
-   call $~lib/rt/stub/__retain
-   local.set $7
-   local.get $1
-   local.set $6
-   i32.const 128
    local.set $5
-   local.get $7
-   local.get $6
-   i32.add
    local.get $5
-   i32.store8
+   local.set $8
+   local.get $1
+   local.set $7
+   i32.const 128
+   local.set $6
+   local.get $8
    local.get $7
-   call $~lib/rt/stub/__release
+   i32.add
+   local.get $6
+   i32.store8
    block $break|0
     local.get $1
     i32.const 1
     i32.add
-    local.set $7
+    local.set $8
     local.get $4
     i32.const 8
     i32.sub
-    local.set $6
+    local.set $7
     loop $loop|0
+     local.get $8
      local.get $7
-     local.get $6
      i32.lt_s
      i32.eqz
      br_if $break|0
-     global.get $assembly/index/buffer
-     call $~lib/rt/stub/__retain
-     local.set $9
-     local.get $7
-     local.set $8
-     i32.const 0
-     local.set $5
-     local.get $9
-     local.get $8
-     i32.add
      local.get $5
-     i32.store8
+     local.set $10
+     local.get $8
+     local.set $9
+     i32.const 0
+     local.set $6
+     local.get $10
      local.get $9
-     call $~lib/rt/stub/__release
-     local.get $7
+     i32.add
+     local.get $6
+     i32.store8
+     local.get $8
      i32.const 1
      i32.add
-     local.set $7
+     local.set $8
      br $loop|0
     end
     unreachable
    end
-   global.get $assembly/index/buffer
-   call $~lib/rt/stub/__retain
-   local.set $9
+   local.get $5
+   local.set $10
    local.get $4
    i32.const 8
    i32.sub
    i32.const 2
    i32.shr_s
-   local.set $8
+   local.set $9
    local.get $2
    call $~lib/polyfills/bswap<i32>
-   local.set $5
+   local.set $6
+   local.get $10
    local.get $9
-   local.get $8
    i32.const 2
    i32.shl
    i32.add
-   local.get $5
+   local.get $6
    i32.store
-   local.get $9
-   call $~lib/rt/stub/__release
-   global.get $assembly/index/buffer
-   call $~lib/rt/stub/__retain
-   local.set $5
+   local.get $5
+   local.set $6
    local.get $4
    i32.const 4
    i32.sub
    i32.const 2
    i32.shr_s
-   local.set $6
+   local.set $7
    local.get $3
    call $~lib/polyfills/bswap<i32>
-   local.set $7
-   local.get $5
+   local.set $8
    local.get $6
+   local.get $7
    i32.const 2
    i32.shl
    i32.add
-   local.get $7
+   local.get $8
    i32.store
-   local.get $5
-   call $~lib/rt/stub/__release
    global.get $assembly/index/temp
    global.get $assembly/index/buffer
    i32.const 0
@@ -2553,41 +4302,36 @@
    global.set $assembly/index/finished
   end
   local.get $0
-  call $~lib/rt/stub/__retain
-  local.set $7
+  local.set $5
+  local.get $5
+  local.set $8
   i32.const 0
-  local.set $9
+  local.set $10
   global.get $assembly/index/H0
   call $~lib/polyfills/bswap<u32>
-  local.set $8
-  local.get $7
-  local.get $9
+  local.set $9
+  local.get $8
+  local.get $10
   i32.const 2
   i32.shl
   i32.add
-  local.get $8
+  local.get $9
   i32.store
-  local.get $7
-  call $~lib/rt/stub/__release
-  local.get $0
-  call $~lib/rt/stub/__retain
+  local.get $5
   local.set $1
   i32.const 1
-  local.set $5
+  local.set $6
   global.get $assembly/index/H1
   call $~lib/polyfills/bswap<u32>
-  local.set $6
+  local.set $7
   local.get $1
-  local.get $5
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $7
   i32.store
-  local.get $1
-  call $~lib/rt/stub/__release
-  local.get $0
-  call $~lib/rt/stub/__retain
+  local.get $5
   local.set $4
   i32.const 2
   local.set $3
@@ -2601,44 +4345,35 @@
   i32.add
   local.get $2
   i32.store
-  local.get $4
-  call $~lib/rt/stub/__release
-  local.get $0
-  call $~lib/rt/stub/__retain
-  local.set $7
+  local.get $5
+  local.set $8
   i32.const 3
-  local.set $9
+  local.set $10
   global.get $assembly/index/H3
   call $~lib/polyfills/bswap<u32>
-  local.set $8
-  local.get $7
-  local.get $9
+  local.set $9
+  local.get $8
+  local.get $10
   i32.const 2
   i32.shl
   i32.add
-  local.get $8
+  local.get $9
   i32.store
-  local.get $7
-  call $~lib/rt/stub/__release
-  local.get $0
-  call $~lib/rt/stub/__retain
+  local.get $5
   local.set $1
   i32.const 4
-  local.set $5
+  local.set $6
   global.get $assembly/index/H4
   call $~lib/polyfills/bswap<u32>
-  local.set $6
+  local.set $7
   local.get $1
-  local.get $5
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $7
   i32.store
-  local.get $1
-  call $~lib/rt/stub/__release
-  local.get $0
-  call $~lib/rt/stub/__retain
+  local.get $5
   local.set $4
   i32.const 5
   local.set $3
@@ -2652,54 +4387,46 @@
   i32.add
   local.get $2
   i32.store
-  local.get $4
-  call $~lib/rt/stub/__release
-  local.get $0
-  call $~lib/rt/stub/__retain
-  local.set $7
+  local.get $5
+  local.set $8
   i32.const 6
-  local.set $9
+  local.set $10
   global.get $assembly/index/H6
   call $~lib/polyfills/bswap<u32>
-  local.set $8
-  local.get $7
-  local.get $9
+  local.set $9
+  local.get $8
+  local.get $10
   i32.const 2
   i32.shl
   i32.add
-  local.get $8
+  local.get $9
   i32.store
-  local.get $7
-  call $~lib/rt/stub/__release
-  local.get $0
-  call $~lib/rt/stub/__retain
+  local.get $5
   local.set $1
   i32.const 7
-  local.set $5
+  local.set $6
   global.get $assembly/index/H7
   call $~lib/polyfills/bswap<u32>
-  local.set $6
+  local.set $7
   local.get $1
-  local.get $5
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
-  local.get $6
+  local.get $7
   i32.store
-  local.get $1
-  call $~lib/rt/stub/__release
   local.get $0
-  call $~lib/rt/stub/__release
+  call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (; 20 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (; 39 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Uint8Array#get:length (; 21 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#get:length (; 40 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 22 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 41 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -2709,8 +4436,8 @@
   i32.shr_u
   i32.gt_u
   if
-   i32.const 328
-   i32.const 376
+   i32.const 576
+   i32.const 624
    i32.const 14
    i32.const 56
    call $~lib/builtins/abort
@@ -2721,7 +4448,7 @@
   i32.shl
   local.tee $1
   i32.const 0
-  call $~lib/rt/stub/__alloc
+  call $~lib/rt/tlsf/__alloc
   local.set $3
   local.get $3
   i32.const 0
@@ -2732,8 +4459,8 @@
   if
    i32.const 12
    i32.const 2
-   call $~lib/rt/stub/__alloc
-   call $~lib/rt/stub/__retain
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
    local.set $0
   end
   local.get $0
@@ -2755,10 +4482,10 @@
   i32.ne
   if
    local.get $5
-   call $~lib/rt/stub/__retain
+   call $~lib/rt/pure/__retain
    drop
    local.get $4
-   call $~lib/rt/stub/__release
+   call $~lib/rt/pure/__release
   end
   local.get $5
   i32.store
@@ -2770,15 +4497,15 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 23 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
   else   
    i32.const 12
    i32.const 3
-   call $~lib/rt/stub/__alloc
-   call $~lib/rt/stub/__retain
+   call $~lib/rt/tlsf/__alloc
+   call $~lib/rt/pure/__retain
   end
   local.get $1
   i32.const 0
@@ -2786,11 +4513,11 @@
   local.set $0
   local.get $0
  )
- (func $assembly/index/hashMe (; 24 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/index/hashMe (; 43 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
-  call $~lib/rt/stub/__retain
+  call $~lib/rt/pure/__retain
   drop
   call $assembly/index/reset
   local.get $0
@@ -2811,22 +4538,179 @@
   local.get $1
   local.set $2
   local.get $0
-  call $~lib/rt/stub/__release
+  call $~lib/rt/pure/__release
   local.get $2
  )
- (func $start (; 25 ;) (type $FUNCSIG$v)
-  global.get $~lib/heap/__heap_base
-  i32.const 15
-  i32.add
-  i32.const 15
-  i32.const -1
-  i32.xor
-  i32.and
-  global.set $~lib/rt/stub/startOffset
-  global.get $~lib/rt/stub/startOffset
-  global.set $~lib/rt/stub/offset
+ (func $start (; 44 ;) (type $FUNCSIG$v)
   call $start:assembly/index
  )
- (func $null (; 26 ;) (type $FUNCSIG$v)
+ (func $~lib/array/Array<u32>#__visit_impl (; 45 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  nop
+ )
+ (func $~lib/rt/pure/__visit (; 46 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  local.get $0
+  global.get $~lib/heap/__heap_base
+  i32.lt_u
+  if
+   return
+  end
+  local.get $0
+  i32.const 16
+  i32.sub
+  local.set $2
+  block $break|0
+   block $case5|0
+    block $case4|0
+     block $case3|0
+      block $case2|0
+       block $case1|0
+        block $case0|0
+         local.get $1
+         local.set $3
+         local.get $3
+         i32.const 1
+         i32.eq
+         br_if $case0|0
+         local.get $3
+         i32.const 2
+         i32.eq
+         br_if $case1|0
+         local.get $3
+         i32.const 3
+         i32.eq
+         br_if $case2|0
+         local.get $3
+         i32.const 4
+         i32.eq
+         br_if $case3|0
+         local.get $3
+         i32.const 5
+         i32.eq
+         br_if $case4|0
+         br $case5|0
+        end
+        local.get $2
+        call $~lib/rt/pure/decrement
+        br $break|0
+       end
+       local.get $2
+       i32.load offset=4
+       i32.const 268435455
+       i32.and
+       i32.const 0
+       i32.gt_u
+       i32.eqz
+       if
+        i32.const 0
+        i32.const 128
+        i32.const 75
+        i32.const 17
+        call $~lib/builtins/abort
+        unreachable
+       end
+       local.get $2
+       local.get $2
+       i32.load offset=4
+       i32.const 1
+       i32.sub
+       i32.store offset=4
+       local.get $2
+       call $~lib/rt/pure/markGray
+       br $break|0
+      end
+      local.get $2
+      call $~lib/rt/pure/scan
+      br $break|0
+     end
+     local.get $2
+     i32.load offset=4
+     local.set $3
+     local.get $3
+     i32.const -268435456
+     i32.and
+     local.get $3
+     i32.const 1
+     i32.add
+     i32.const -268435456
+     i32.and
+     i32.eq
+     i32.eqz
+     if
+      i32.const 0
+      i32.const 128
+      i32.const 86
+      i32.const 6
+      call $~lib/builtins/abort
+      unreachable
+     end
+     local.get $2
+     local.get $3
+     i32.const 1
+     i32.add
+     i32.store offset=4
+     local.get $3
+     i32.const 1879048192
+     i32.and
+     i32.const 0
+     i32.ne
+     if
+      local.get $2
+      call $~lib/rt/pure/scanBlack
+     end
+     br $break|0
+    end
+    local.get $2
+    call $~lib/rt/pure/collectWhite
+    br $break|0
+   end
+   i32.const 0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 128
+    i32.const 97
+    i32.const 24
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+ )
+ (func $~lib/rt/__visit_members (; 47 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  block $block$4$break
+   block $switch$1$default
+    block $switch$1$case$6
+     block $switch$1$case$4
+      block $switch$1$case$2
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load
+       br_table $switch$1$case$2 $switch$1$case$2 $switch$1$case$4 $switch$1$case$4 $switch$1$case$6 $switch$1$default
+      end
+      return
+     end
+     br $block$4$break
+    end
+    local.get $0
+    local.get $1
+    call $~lib/array/Array<u32>#__visit_impl
+    br $block$4$break
+   end
+   unreachable
+  end
+  local.get $0
+  i32.load
+  local.tee $2
+  if
+   local.get $2
+   local.get $1
+   call $~lib/rt/pure/__visit
+  end
+  return
+ )
+ (func $null (; 48 ;) (type $FUNCSIG$v)
  )
 )

--- a/build/untouched.wat
+++ b/build/untouched.wat
@@ -42,10 +42,10 @@
  (global $assembly/index/H7 (mut i32) (i32.const 0))
  (global $assembly/index/temp (mut i32) (i32.const 0))
  (global $assembly/index/buffer (mut i32) (i32.const 0))
+ (global $assembly/index/out (mut i32) (i32.const 0))
  (global $assembly/index/bufferLength (mut i32) (i32.const 0))
  (global $assembly/index/bytesHashed (mut i32) (i32.const 0))
  (global $assembly/index/finished (mut i32) (i32.const 0))
- (global $assembly/index/out (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 832))
  (global $~lib/heap/__heap_base i32 (i32.const 876))
  (export "memory" (memory $0))
@@ -4005,7 +4005,7 @@
    call $~lib/rt/pure/__release
    i32.const 680
    i32.const 792
-   i32.const 143
+   i32.const 145
    i32.const 4
    call $~lib/builtins/abort
    unreachable

--- a/build/untouched.wat
+++ b/build/untouched.wat
@@ -4183,8 +4183,6 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -4222,75 +4220,33 @@
    i32.add
    local.get $6
    i32.store8
-   block $break|0
-    local.get $1
-    i32.const 1
-    i32.add
-    local.set $8
-    local.get $4
-    i32.const 8
-    i32.sub
-    local.set $7
-    loop $loop|0
-     local.get $8
-     local.get $7
-     i32.lt_s
-     i32.eqz
-     br_if $break|0
-     local.get $5
-     local.set $10
-     local.get $8
-     local.set $9
-     i32.const 0
-     local.set $6
-     local.get $10
-     local.get $9
-     i32.add
-     local.get $6
-     i32.store8
-     local.get $8
-     i32.const 1
-     i32.add
-     local.set $8
-     br $loop|0
-    end
-    unreachable
-   end
    local.get $5
-   local.set $10
+   local.get $1
+   i32.add
+   i32.const 1
+   i32.add
+   i32.const 0
    local.get $4
+   local.get $1
+   i32.sub
+   i32.const 9
+   i32.sub
+   call $~lib/memory/memory.fill
+   local.get $5
+   local.get $4
+   i32.add
    i32.const 8
    i32.sub
-   i32.const 2
-   i32.shr_s
-   local.set $9
    local.get $2
    call $~lib/polyfills/bswap<i32>
-   local.set $6
-   local.get $10
-   local.get $9
-   i32.const 2
-   i32.shl
-   i32.add
-   local.get $6
    i32.store
    local.get $5
-   local.set $6
    local.get $4
+   i32.add
    i32.const 4
    i32.sub
-   i32.const 2
-   i32.shr_s
-   local.set $7
    local.get $3
    call $~lib/polyfills/bswap<i32>
-   local.set $8
-   local.get $6
-   local.get $7
-   i32.const 2
-   i32.shl
-   i32.add
-   local.get $8
    i32.store
    global.get $assembly/index/temp
    global.get $assembly/index/buffer
@@ -4306,68 +4262,82 @@
   local.get $5
   local.set $8
   i32.const 0
-  local.set $10
+  local.set $7
   global.get $assembly/index/H0
   call $~lib/polyfills/bswap<u32>
-  local.set $9
+  local.set $6
   local.get $8
-  local.get $10
+  local.get $7
   i32.const 2
   i32.shl
   i32.add
-  local.get $9
+  local.get $6
   i32.store
   local.get $5
-  local.set $1
+  local.set $3
   i32.const 1
-  local.set $6
+  local.set $2
   global.get $assembly/index/H1
   call $~lib/polyfills/bswap<u32>
-  local.set $7
-  local.get $1
-  local.get $6
+  local.set $1
+  local.get $3
+  local.get $2
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $1
   i32.store
   local.get $5
-  local.set $4
+  local.set $7
   i32.const 2
-  local.set $3
+  local.set $6
   global.get $assembly/index/H2
   call $~lib/polyfills/bswap<u32>
-  local.set $2
-  local.get $4
-  local.get $3
+  local.set $4
+  local.get $7
+  local.get $6
   i32.const 2
   i32.shl
   i32.add
-  local.get $2
+  local.get $4
   i32.store
   local.get $5
-  local.set $8
+  local.set $2
   i32.const 3
-  local.set $10
+  local.set $1
   global.get $assembly/index/H3
   call $~lib/polyfills/bswap<u32>
-  local.set $9
-  local.get $8
-  local.get $10
+  local.set $8
+  local.get $2
+  local.get $1
   i32.const 2
   i32.shl
   i32.add
-  local.get $9
+  local.get $8
+  i32.store
+  local.get $5
+  local.set $6
+  i32.const 4
+  local.set $4
+  global.get $assembly/index/H4
+  call $~lib/polyfills/bswap<u32>
+  local.set $3
+  local.get $6
+  local.get $4
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $3
   i32.store
   local.get $5
   local.set $1
-  i32.const 4
-  local.set $6
-  global.get $assembly/index/H4
+  i32.const 5
+  local.set $8
+  global.get $assembly/index/H5
   call $~lib/polyfills/bswap<u32>
   local.set $7
   local.get $1
-  local.get $6
+  local.get $8
   i32.const 2
   i32.shl
   i32.add
@@ -4375,9 +4345,9 @@
   i32.store
   local.get $5
   local.set $4
-  i32.const 5
+  i32.const 6
   local.set $3
-  global.get $assembly/index/H5
+  global.get $assembly/index/H6
   call $~lib/polyfills/bswap<u32>
   local.set $2
   local.get $4
@@ -4389,31 +4359,17 @@
   i32.store
   local.get $5
   local.set $8
-  i32.const 6
-  local.set $10
-  global.get $assembly/index/H6
-  call $~lib/polyfills/bswap<u32>
-  local.set $9
-  local.get $8
-  local.get $10
-  i32.const 2
-  i32.shl
-  i32.add
-  local.get $9
-  i32.store
-  local.get $5
-  local.set $1
   i32.const 7
-  local.set $6
+  local.set $7
   global.get $assembly/index/H7
   call $~lib/polyfills/bswap<u32>
-  local.set $7
-  local.get $1
-  local.get $6
+  local.set $6
+  local.get $8
+  local.get $7
   i32.const 2
   i32.shl
   i32.add
-  local.get $7
+  local.get $6
   i32.store
   local.get $0
   call $~lib/rt/pure/__release

--- a/build/untouched.wat
+++ b/build/untouched.wat
@@ -30,7 +30,7 @@
  (global $~lib/rt/pure/ROOTS (mut i32) (i32.const 0))
  (global $~lib/ASC_SHRINK_LEVEL i32 (i32.const 0))
  (global $assembly/index/UINT8ARRAY_ID i32 (i32.const 3))
- (global $assembly/index/digestLength i32 (i32.const 32))
+ (global $assembly/index/DIGEST_LENGTH i32 (i32.const 32))
  (global $assembly/index/K i32 (i32.const 544))
  (global $assembly/index/H0 (mut i32) (i32.const 0))
  (global $assembly/index/H1 (mut i32) (i32.const 0))
@@ -40,8 +40,8 @@
  (global $assembly/index/H5 (mut i32) (i32.const 0))
  (global $assembly/index/H6 (mut i32) (i32.const 0))
  (global $assembly/index/H7 (mut i32) (i32.const 0))
- (global $assembly/index/temp (mut i32) (i32.const 0))
  (global $assembly/index/buffer (mut i32) (i32.const 0))
+ (global $assembly/index/temp (mut i32) (i32.const 0))
  (global $assembly/index/out (mut i32) (i32.const 0))
  (global $assembly/index/bufferLength (mut i32) (i32.const 0))
  (global $assembly/index/bytesHashed (mut i32) (i32.const 0))
@@ -3522,15 +3522,15 @@
   (local $0 i32)
   (local $1 i32)
   i32.const 0
-  i32.const 256
-  call $~lib/arraybuffer/ArrayBuffer#constructor
-  global.set $assembly/index/temp
-  i32.const 0
   i32.const 128
   call $~lib/arraybuffer/ArrayBuffer#constructor
   global.set $assembly/index/buffer
   i32.const 0
-  global.get $assembly/index/digestLength
+  i32.const 256
+  call $~lib/arraybuffer/ArrayBuffer#constructor
+  global.set $assembly/index/temp
+  i32.const 0
+  global.get $assembly/index/DIGEST_LENGTH
   call $~lib/arraybuffer/ArrayBuffer#constructor
   global.set $assembly/index/out
  )
@@ -3575,14 +3575,14 @@
   global.get $assembly/index/temp
   call $~lib/arraybuffer/ArrayBuffer#get:byteLength
   call $~lib/memory/memory.fill
+  global.get $assembly/index/out
+  i32.const 0
+  global.get $assembly/index/out
+  call $~lib/arraybuffer/ArrayBuffer#get:byteLength
+  call $~lib/memory/memory.fill
   call $assembly/index/reset
  )
- (func $~lib/typedarray/Uint8Array#get:buffer (; 33 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
-  local.get $0
-  i32.load
-  call $~lib/rt/pure/__retain
- )
- (func $assembly/index/hashBlocks (; 34 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+ (func $assembly/index/hashBlocks (; 33 ;) (type $FUNCSIG$iiiii) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
@@ -3984,7 +3984,7 @@
   end
   local.get $2
  )
- (func $assembly/index/update (; 35 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $assembly/index/update (; 34 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -3993,9 +3993,6 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
-  (local $10 i32)
-  (local $11 i32)
-  (local $12 i32)
   local.get $0
   call $~lib/rt/pure/__retain
   drop
@@ -4005,27 +4002,20 @@
    call $~lib/rt/pure/__release
    i32.const 680
    i32.const 792
-   i32.const 145
+   i32.const 146
    i32.const 4
    call $~lib/builtins/abort
    unreachable
   end
   local.get $0
-  call $~lib/typedarray/Uint8Array#get:buffer
-  local.tee $2
-  call $~lib/rt/pure/__retain
-  local.set $3
-  local.get $0
   i32.load offset=4
-  local.set $4
+  local.set $2
   global.get $assembly/index/temp
-  local.set $5
+  local.set $3
   global.get $assembly/index/buffer
-  local.set $6
-  local.get $3
-  local.set $7
+  local.set $4
   i32.const 0
-  local.set $8
+  local.set $5
   global.get $assembly/index/bytesHashed
   local.get $1
   i32.add
@@ -4048,33 +4038,33 @@
      end
      i32.eqz
      br_if $break|0
-     local.get $6
-     local.set $12
+     local.get $4
+     local.set $9
      global.get $assembly/index/bufferLength
-     local.tee $9
+     local.tee $6
      i32.const 1
      i32.add
      global.set $assembly/index/bufferLength
-     local.get $9
-     local.set $11
-     local.get $4
-     local.set $10
-     local.get $8
-     local.tee $9
+     local.get $6
+     local.set $8
+     local.get $2
+     local.set $7
+     local.get $5
+     local.tee $6
      i32.const 1
      i32.add
-     local.set $8
-     local.get $9
-     local.set $9
-     local.get $10
-     local.get $9
+     local.set $5
+     local.get $6
+     local.set $6
+     local.get $7
+     local.get $6
      i32.add
      i32.load8_u
-     local.set $9
-     local.get $12
-     local.get $11
-     i32.add
+     local.set $6
      local.get $9
+     local.get $8
+     i32.add
+     local.get $6
      i32.store8
      local.get $1
      i32.const 1
@@ -4088,8 +4078,8 @@
    i32.const 64
    i32.eq
    if
-    local.get $5
-    local.get $6
+    local.get $3
+    local.get $4
     i32.const 0
     i32.const 64
     call $assembly/index/hashBlocks
@@ -4102,39 +4092,35 @@
   i32.const 64
   i32.ge_s
   if
+   local.get $3
+   local.get $2
    local.get $5
-   local.get $7
-   local.get $8
    local.get $1
    call $assembly/index/hashBlocks
-   local.set $8
+   local.set $5
    local.get $1
    i32.const 63
    i32.and
    local.set $1
   end
-  local.get $6
   local.get $4
-  local.get $8
+  local.get $2
+  local.get $5
   i32.add
   local.get $1
   call $~lib/memory/memory.copy
-  local.get $8
+  local.get $5
   local.get $1
   i32.add
-  local.set $8
+  local.set $5
   global.get $assembly/index/bufferLength
   local.get $1
   i32.add
   global.set $assembly/index/bufferLength
-  local.get $2
-  call $~lib/rt/pure/__release
-  local.get $3
-  call $~lib/rt/pure/__release
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/polyfills/bswap<i32> (; 36 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<i32> (; 35 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -4148,7 +4134,7 @@
   i32.or
   return
  )
- (func $~lib/polyfills/bswap<u32> (; 37 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/polyfills/bswap<u32> (; 36 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.const -16711936
   i32.and
@@ -4162,7 +4148,7 @@
   i32.or
   return
  )
- (func $assembly/index/finish (; 38 ;) (type $FUNCSIG$vi) (param $0 i32)
+ (func $assembly/index/finish (; 37 ;) (type $FUNCSIG$vi) (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4365,15 +4351,15 @@
   local.get $0
   call $~lib/rt/pure/__release
  )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (; 39 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (; 38 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   i32.load offset=8
  )
- (func $~lib/typedarray/Uint8Array#get:length (; 40 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#get:length (; 39 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   local.get $0
   call $~lib/arraybuffer/ArrayBufferView#get:byteLength
  )
- (func $~lib/arraybuffer/ArrayBufferView#constructor (; 41 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ (func $~lib/arraybuffer/ArrayBufferView#constructor (; 40 ;) (type $FUNCSIG$iiii) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
@@ -4444,7 +4430,7 @@
   i32.store offset=8
   local.get $0
  )
- (func $~lib/typedarray/Uint8Array#constructor (; 42 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
+ (func $~lib/typedarray/Uint8Array#constructor (; 41 ;) (type $FUNCSIG$iii) (param $0 i32) (param $1 i32) (result i32)
   local.get $0
   if (result i32)
    local.get $0
@@ -4460,7 +4446,7 @@
   local.set $0
   local.get $0
  )
- (func $assembly/index/hashMe (; 43 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
+ (func $assembly/index/hashMe (; 42 ;) (type $FUNCSIG$ii) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   local.get $0
@@ -4474,13 +4460,13 @@
   global.get $assembly/index/out
   call $assembly/index/finish
   i32.const 0
-  global.get $assembly/index/digestLength
+  global.get $assembly/index/DIGEST_LENGTH
   call $~lib/typedarray/Uint8Array#constructor
   local.set $1
   local.get $1
   i32.load offset=4
   global.get $assembly/index/out
-  global.get $assembly/index/digestLength
+  global.get $assembly/index/DIGEST_LENGTH
   call $~lib/memory/memory.copy
   local.get $1
   local.set $2
@@ -4488,13 +4474,13 @@
   call $~lib/rt/pure/__release
   local.get $2
  )
- (func $start (; 44 ;) (type $FUNCSIG$v)
+ (func $start (; 43 ;) (type $FUNCSIG$v)
   call $start:assembly/index
  )
- (func $~lib/array/Array<u32>#__visit_impl (; 45 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/array/Array<u32>#__visit_impl (; 44 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   nop
  )
- (func $~lib/rt/pure/__visit (; 46 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/pure/__visit (; 45 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
   local.get $0
@@ -4624,7 +4610,7 @@
    end
   end
  )
- (func $~lib/rt/__visit_members (; 47 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
+ (func $~lib/rt/__visit_members (; 46 ;) (type $FUNCSIG$vii) (param $0 i32) (param $1 i32)
   (local $2 i32)
   block $block$4$break
    block $switch$1$default
@@ -4658,6 +4644,6 @@
   end
   return
  )
- (func $null (; 48 ;) (type $FUNCSIG$v)
+ (func $null (; 47 ;) (type $FUNCSIG$v)
  )
 )

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "fast-sha256": "^1.1.0"
   },
   "scripts": {
-    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --runtime stub --validate --debug",
-    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --runtime stub --validate -O3",
+    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --runtime full --validate --debug",
+    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --runtime full --validate -O3 --noAssert",
     "build": "yarn asbuild:untouched && yarn asbuild:optimized",
     "test": "asp --nortrace --verbose",
     "test:ci": "asp --nortrace 2> /dev/null"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --runtime full --validate --debug",
     "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --runtime full --validate -O3 --noAssert",
     "build": "yarn asbuild:untouched && yarn asbuild:optimized",
-    "test": "asp --nortrace --verbose",
-    "test:ci": "asp --nortrace 2> /dev/null"
+    "test": "asp --verbose",
+    "test:ci": "asp 2> /dev/null"
   }
 }

--- a/run.js
+++ b/run.js
@@ -76,6 +76,6 @@ console.time('js (fast-sha256)');
 
 console.timeEnd('js (fast-sha256)');
 
-console.log(toHexString(wasm.__getArray(messageOut)), '7321348c8894678447b54c888fdbc4e4b825bf4d1eb0cfb27874286a23ea9fd2');
-console.log(toHexString(wasm.__getArray(amessageOut)), 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
-console.log(toHexString(wasm.__getArray(emptymessageOut)), 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+console.log(toHexString(wasm.__getArrayView(messageOut)), '7321348c8894678447b54c888fdbc4e4b825bf4d1eb0cfb27874286a23ea9fd2');
+console.log(toHexString(wasm.__getArrayView(amessageOut)), 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+console.log(toHexString(wasm.__getArrayView(emptymessageOut)), 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');

--- a/run.js
+++ b/run.js
@@ -29,14 +29,14 @@ function jsHash(msg) {
 
 const toHexString = byteArray => byteArray.reduce((acc, val) => (acc + ('0' + val.toString(16)).slice(-2)), '');
 
-const emptyMessage = new Uint8Array(Buffer.from(''));
+const emptyMessage = new Uint8Array(0);
 
-const Message = new Uint8Array(Buffer.from('Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.'));
+const Message = Buffer.from('Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.');
 
 const aMessage = new Uint8Array([97,98,99]);
 
-const randomMessage2048 = new Uint8Array(crypto.randomBytes(2048));
-const randomMessage16384 = new Uint8Array(crypto.randomBytes(16384));
+const randomMessage2048 = crypto.randomBytes(2048);
+const randomMessage16384 = crypto.randomBytes(16384);
 
 const message = wasm.__retain(wasm.__allocArray(wasm.UINT8ARRAY_ID, Message));
 const amessage = wasm.__retain(wasm.__allocArray(wasm.UINT8ARRAY_ID, aMessage));


### PR DESCRIPTION
Switch to full ARC + GC runtime for avoiding memory leaks

Usage:
```ts
// prepare input
const msg = Buffer.from("Hello");
const inputRef = wasm.__retain(wasm.__allocArray(wasm.UINT8ARRAY_ID, msg));

const outputRef = wasm.hashMe(inputRef); // hash

// read output buffer
const hexResult = toHexString(wasm.__getArray(outputRef));
console.log(hexResult);

wasm.__release(inputRef); // free input array
wasm.__release(outputRef); // free output array
```