### PR TITLE
Improvements & fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,18 @@ const hash = sha256(message);
 
 We also expose the lower level WASM exports for those that may wish to use it. It can be accessed as follows:
 ```JS
-import sha256, {wasm} from "@chainsafe/sha256"
+import { wasm } from "@chainsafe/sha256"
 
 const buffer = Buffer.from("Hello world");
-const array = wasm.__retain(wasm.__allocArray(wasm.UINT8ARRAY_ID, buffer));
-const message = wasm.sha256(array)
+const input  = wasm.__retain(wasm.__allocArray(wasm.UINT8ARRAY_ID, buffer));
+const result = wasm.hash(input);
+const output = wasm.__getUint8Array(result);
 
 // To prevent memory leaks
 wasm.__release(array);
-wasm.__release(message);
+wasm.__release(result);
 
-console.log(toHexString(wasm.__getUint8Array(message)));
+console.log(toHexString(output));
 ```
 
 ### License

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -200,7 +200,7 @@ export function finish(out: ArrayBuffer): void {
   store32(outPtr, 7, bswap(H7));
 }
 
-export function digest (): Uint8Array {
+export function digest(): Uint8Array {
   finish(out);
   let ret = new Uint8Array(DIGEST_LENGTH);
   memory.copy(ret.dataStart, changetype<usize>(out), DIGEST_LENGTH);

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,12 @@ import wasm from "./wasm";
  */
 export default function sha256(message) {
   // @ts-ignore
-  const buf = new Uint8Array(Buffer.from(message));
+  const buf = Buffer.from(message);
   const arr = wasm.__retain(wasm.__allocArray(wasm.UINT8ARRAY_ID, buf));
   const pointer = wasm.hash(arr);
-  const result = wasm.__getArray(pointer)
+  const result = wasm.__getUint8Array(pointer);
   wasm.__release(arr);
-  wasm.__release(result);
+  wasm.__release(pointer);
   return result;
 }
 
@@ -37,6 +37,6 @@ export function digest() {
   // @ts-ignore
   const digestPointer = wasm.digest();
   const digest = wasm.__getUint8Array(digestPointer);
-  wasm.__release(digestPointer)
+  wasm.__release(digestPointer);
   return digest;
 }


### PR DESCRIPTION
- [x] Fix  should be `wasm.__release(pointer)` not `wasm.__release(result)`. That's caused to significant performance degradation.
- [x] Fix low level example in README
- [x] Use fast `__getUint8Array` instead `__getArray` for `sha256`