### PR TITLE
Add toHexString to public api

### DIFF
--- a/assembly/__tests__/example.spec.ts
+++ b/assembly/__tests__/example.spec.ts
@@ -1,21 +1,4 @@
-import { hash } from '..';
-
-// Stolen from wasm-crypto
-function toHexString(bin: Uint8Array): string {
-  let bin_len = bin.length;
-  let hex = "";
-  for (let i = 0; i < bin_len; i++) {
-    let bin_i = bin[i] as u32;
-    let c = bin_i & 0xf;
-    let b = bin_i >> 4;
-    let x: u32 = ((87 + c + (((c - 10) >> 8) & ~38)) << 8) |
-        (87 + b + (((b - 10) >> 8) & ~38));
-    hex += String.fromCharCode(x as u8);
-    x >>= 8;
-    hex += String.fromCharCode(x as u8);
-  }
-  return hex;
-}
+import { hash, toHexString } from '..';
 
 describe("example", () => {
   it("Hash: empty array", () => {

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -216,3 +216,19 @@ export function hash(data: Uint8Array): Uint8Array {
   memory.copy(ret.dataStart, changetype<usize>(out), DIGEST_LENGTH);
   return ret;
 }
+
+export function toHexString(bin: Uint8Array): string {
+  let bin_len = bin.length;
+  let hex = "";
+  for (let i = 0; i < bin_len; i++) {
+    let bin_i = bin[i] as u32;
+    let c = bin_i & 0xf;
+    let b = bin_i >> 4;
+    let x: u32 = ((87 + c + (((c - 10) >> 8) & ~38)) << 8) |
+        (87 + b + (((b - 10) >> 8) & ~38));
+    hex += String.fromCharCode(x as u8);
+    x >>= 8;
+    hex += String.fromCharCode(x as u8);
+  }
+  return hex;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,12 @@ export function digest() {
   return digest;
 }
 
+export function toHexString(bytes) {
+  checkInit();
+  const hex = wasm.toHexString(bytes);
+  return hex;
+}
+
 function checkInit() {
   if(!wasm) throw new Error("Please call 'initSha256' before using other methods");
 }


### PR DESCRIPTION
Moves `toHexString` from __test__ to index.ts, making it a public
convenience function. This was motivated by a need for a way to convert
hashes into hex string for hyperledger/sawtooth-sabre compatibility.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>