### PR TITLE
Disclude wasm/wast blobs from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "files": [
-        "lib",
-        "build"
+        "lib"
     ],
     "scripts": {
         "prebuild": "rm -rf ./dist",


### PR DESCRIPTION
Drops unpacked package size from 87.5kb to 12.1 kB