### PR TITLE
replacing SHA256.ctx with staticInstance

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,8 +4,6 @@ export default class SHA256 {
   update(data: Uint8Array): this;
   final(): Uint8Array;
 
-  static ctx: SHA256;
   static digest(data: Uint8Array): Uint8Array;
   static digest64(data: Uint8Array): Uint8Array;
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -31,31 +31,29 @@ export default class SHA256 {
   }
 
   static digest(data) {
-    if (data.length <= SHA256.ctx.INPUT_LENGTH) {
-      const input = new Uint8Array(SHA256.ctx.memory.buffer, SHA256.ctx.input.value, SHA256.ctx.INPUT_LENGTH);
+    if (data.length <= staticInstance.ctx.INPUT_LENGTH) {
+      const input = new Uint8Array(staticInstance.ctx.memory.buffer, staticInstance.ctx.input.value, staticInstance.ctx.INPUT_LENGTH);
       input.set(data);
-      SHA256.ctx.digest(data.length);
+      staticInstance.ctx.digest(data.length);
       const output = new Uint8Array(32);
-      output.set(new Uint8Array(SHA256.ctx.memory.buffer, SHA256.ctx.output.value, 32));
+      output.set(new Uint8Array(staticInstance.ctx.memory.buffer, staticInstance.ctx.output.value, 32));
       return output;
     }
-    return SHA256.ctx.init().update(data).final();
+    return staticInstance.init().update(data).final();
   }
 
   static digest64(data) {
     if (data.length==64) {
-      const input = new Uint8Array(SHA256.ctx.memory.buffer, SHA256.ctx.input.value, SHA256.ctx.INPUT_LENGTH);
+      const input = new Uint8Array(staticInstance.ctx.memory.buffer, staticInstance.ctx.input.value, staticInstance.ctx.INPUT_LENGTH);
       input.set(data);
-      SHA256.ctx.digest64(SHA256.ctx.input.value,SHA256.ctx.output.value);
+      staticInstance.ctx.digest64(staticInstance.ctx.input.value,staticInstance.ctx.output.value);
       const output = new Uint8Array(32);
-      output.set(new Uint8Array(SHA256.ctx.memory.buffer, SHA256.ctx.output.value, 32));
+      output.set(new Uint8Array(staticInstance.ctx.memory.buffer, staticInstance.ctx.output.value, 32));
       return output;
     }
     throw new Error("InvalidLengthForDigest64");
   }
 
-
 }
 
 const staticInstance = new SHA256();
-SHA256.ctx = staticInstance.ctx;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -36,6 +36,19 @@ describe("sha256", function () {
             const output64 = Buffer.from(sha256.default.digest64(input)).toString("hex")
             expect(output).to.be.equal(output64)
         });
+
+        it('1024 digest test', function () {
+            let input = "12345678";
+            input=`${input}${input}${input}${input}${input}${input}${input}${input}`;//64 length
+            input=`${input}${input}${input}${input}${input}${input}${input}${input}`;//512 length
+            input=`${input}${input}`;//1024 length
+            input=Buffer.from(input,"utf8");
+            expect(input.length).to.be.equal(1024)
+
+            const output = Buffer.from(sha256.default.digest(input)).toString("hex");
+            expect(output).to.be.equal("54c7cb8a82d68145fd5f5da4103f5a66f422dbea23d9fc9f40f59b1dcf5403a9");
+        });
+
     })
 
 });


### PR DESCRIPTION
#47 

*fixes the broken update call from static digest
*fixes the undefined length on ctx of sha256's static digest call
*removal of static ctx
*new test for length 1023





---------------------------------------
PS: *this work has not been funded or granted by anyone. if you think this adds value to the ecosystem you could tip the author at: [0xb44ddd63d0e27bb3cd8046478b20c0465058ff04](https://etherscan.io/address/0xb44ddd63d0e27bb3cd8046478b20c0465058ff04)*