### PR TITLE
normal digest mem opt for < 512 bytes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default class SHA256 {
   }
 
   static digest(data) {
-    if (data.length == 64) {
+    if (data.length === 64) {
       return SHA256.digest64(data);
     }
     if (data.length <= staticInstance.ctx.INPUT_LENGTH) {
@@ -51,7 +51,7 @@ export default class SHA256 {
   }
 
   static digest64(data) {
-    if (data.length == 64) {
+    if (data.length === 64) {
       staticInstance.uint8InputArray.set(data);
       staticInstance.ctx.digest64(staticInstance.wasmInputValue, staticInstance.wasmOutputValue);
       const output = new Uint8Array(32);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {newInstance} from './wasm';
+import {newInstance} from "./wasm";
 
 export default class SHA256 {
   constructor() {
@@ -37,19 +37,21 @@ export default class SHA256 {
   }
 
   static digest(data) {
+    if (data.length == 64) {
+      return SHA256.digest64(data);
+    }
     if (data.length <= staticInstance.ctx.INPUT_LENGTH) {
-      const input = new Uint8Array(staticInstance.ctx.memory.buffer, staticInstance.ctx.input.value, staticInstance.ctx.INPUT_LENGTH);
-      input.set(data);
+      staticInstance.uint8InputArray.set(data);
       staticInstance.ctx.digest(data.length);
       const output = new Uint8Array(32);
-      output.set(new Uint8Array(staticInstance.ctx.memory.buffer, staticInstance.ctx.output.value, 32));
+      output.set(staticInstance.uint8OutputArray);
       return output;
     }
     return staticInstance.init().update(data).final();
   }
 
   static digest64(data) {
-    if (data.length==64) {
+    if (data.length == 64) {
       staticInstance.uint8InputArray.set(data);
       staticInstance.ctx.digest64(staticInstance.wasmInputValue, staticInstance.wasmOutputValue);
       const output = new Uint8Array(32);
@@ -98,7 +100,7 @@ const staticInstance = new SHA256();
  * This function contains multiple same procedures but we intentionally
  * do it step by step to improve performance a bit.
  **/
- export function hashObjectToByteArray(obj, byteArr, offset) {
+export function hashObjectToByteArray(obj, byteArr, offset) {
   let tmp = obj.h0;
   byteArr[0 + offset] = tmp & 0xff;
   tmp = tmp >> 8;


### PR DESCRIPTION
1. mem optimization for a  case which might have got skipped in  @tuyennhv 's memopt PR.
2. allowing normal digest to harness digest64 when length=64, digest64 still stays ~1.5-2% faster, just because of the control flow change in digest, hence still recommending digest64  direct usage in super hot paths. could be useful where dynamically size could luckily come 64, for e.g. in ssz's hash module.

![image](https://user-images.githubusercontent.com/76567250/129756793-99788b62-3083-4474-bee9-adbd959aa5a9.png)






